### PR TITLE
Build multi-architecture release images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-release:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      owner: ${{ steps.owner.outputs.owner }}
+      image: ghcr.io/${{ steps.owner.outputs.owner }}/codebuddy2api
 
     steps:
       - name: Checkout repository
@@ -54,6 +59,25 @@ jobs:
           lower_owner="$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           echo "owner=$lower_owner" >> "$GITHUB_OUTPUT"
 
+  build:
+    needs: prepare
+    name: Build ${{ matrix.arch }} image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -64,21 +88,89 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push image
+      - name: Build and push ${{ matrix.arch }} image by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: |
-            ghcr.io/${{ steps.owner.outputs.owner }}/codebuddy2api:${{ steps.version.outputs.version }}
-            ghcr.io/${{ steps.owner.outputs.owner }}/codebuddy2api:latest
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export image digest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload ${{ matrix.arch }} image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Create and push multi-architecture image tags
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ needs.prepare.outputs.image }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          digest_refs=()
+          while IFS= read -r -d '' digest_file; do
+            digest_refs+=("${IMAGE_NAME}@sha256:$(basename "$digest_file")")
+          done < <(find /tmp/digests -type f -print0 | sort -z)
+
+          if [[ "${#digest_refs[@]}" -ne 2 ]]; then
+            echo "Expected 2 image digests, found ${#digest_refs[@]}." >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:${VERSION}" \
+            --tag "${IMAGE_NAME}:latest" \
+            "${digest_refs[@]}"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          IMAGE_NAME: ghcr.io/${{ steps.owner.outputs.owner }}/codebuddy2api:${{ steps.version.outputs.version }}
-          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
-          RELEASE_TITLE: ${{ steps.version.outputs.version }}
+          IMAGE_NAME: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          RELEASE_TITLE: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
### Motivation
- The existing release workflow only built an amd64 image and created the release immediately, which prevents providing a proper multi-architecture image.
- We need to produce both `amd64` and `arm64` images in parallel and ensure the final tags and GitHub release are created only after both builds complete.
- The `arm64` build must run on a native ARM runner (no QEMU emulation) to satisfy the environment requirement.

### Description
- Split the single job into three jobs: `prepare` (compute version/owner), `build` (parallel matrix for architectures), and `release` (assemble multi-arch tags and create the GitHub release). 
- Added a build matrix including `amd64` (`linux/amd64` on `ubuntu-latest`) and `arm64` (`linux/arm64` on `ubuntu-24.04-arm`) so the arm64 build runs on a native ARM runner.
- Each matrix job pushes an architecture-specific image by digest and uploads a small digest artifact using `actions/upload-artifact`; the `release` job downloads these artifacts and combines them.
- The `release` job uses `docker buildx imagetools create` to create `version` and `latest` multi-architecture tags and then creates the GitHub release after tags are pushed.

### Testing
- Ran `git diff --check` and it completed without errors.
- Validated the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"` and it returned `yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46aa53da74832582bc2a64153b9dee)