### PR TITLE
fix: resolve Docker build failure for missing /app/config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,8 @@ ENV NODE_ENV=production \
 
 COPY --from=builder --chown=bun:bun /app/.next/standalone ./
 COPY --from=builder --chown=bun:bun /app/.next/static ./.next/static
-COPY --from=builder --chown=bun:bun /app/config ./config
 
-RUN mkdir -p /app/.codebuddy_creds && \
+RUN mkdir -p /app/config /app/.codebuddy_creds && \
     chown -R bun:bun /app
 
 USER bun


### PR DESCRIPTION
## Problem

The `docker-build` job in CI fails with:

```
ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/app/config": not found
```

## Root cause

The Dockerfile `COPY --from=builder /app/config ./config` instruction references a directory that does not exist in the builder stage. The `config/` directory is **not** part of the repository and is **not** produced by `next build`. It is a runtime-mounted volume (see `deploy/docker-compose.yml` → `../config:/app/config` and the `codebuddy2api-config` PVC in `deploy/k8s/codebuddy2api.yaml`). The app creates `config/config.json` on demand via `fs.mkdirSync(path.dirname(getConfigPath()), { recursive: true })` in `lib/server/config.ts`.

Because BuildKit tries to compute a cache key checksum for `/app/config` during `COPY`, the missing path aborts the build before the image can be created.

## Fix

- Remove the `COPY --from=builder /app/config ./config` line.
- Create `/app/config` in the runner stage (`mkdir -p /app/config /app/.codebuddy_creds`) with the correct ownership, so the app has a writable home for `config.json` when no volume is mounted.

This keeps the runtime behavior identical for docker-compose / k8s deployments (the mount overlays the empty directory) while letting the image build standalone.

## Verification

- `bun run lint` ✅
- `bun run format:check` ✅
- `bun run typecheck` ✅
- `bun run test:coverage` ✅ (91.72% statements, ≥ 90% threshold)
- `bun run build` ✅