### PR TITLE
feat: add managed access keys for credential routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ CODEBUDDY_API_KEY=
 
 # Runtime behavior
 CODEBUDDY_LOG_LEVEL=INFO
-CODEBUDDY_ROTATION_COUNT=1
 
 # Advanced optional overrides
 # CODEBUDDY_API_ENDPOINT=https://copilot.tencent.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,6 @@
 - Run `bun run lint`.
 - Run `bun run format:check`.
 - Run `bun run typecheck`.
+- Treat unit test coverage below 90% as a blocking failure.
 - Run `bun run test:coverage` and confirm the reported coverage stays at or above 90%.
 - Run `bun run build`.

--- a/README.md
+++ b/README.md
@@ -118,25 +118,22 @@ const response = await client.chat.completions.create({
 console.log(response.choices[0]?.message?.content);
 ```
 
-### Password Protection
+### Authentication
 
-If `CODEBUDDY_PASSWORD` is set, include it as a Bearer token:
-
-```
-Authorization: Bearer <password>
-```
+- Client inference routes (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/models`) accept managed access keys. Send them as `Authorization: Bearer <access-key>` or `x-api-key: <access-key>`.
+- During migration, if `CODEBUDDY_PASSWORD` is still set and no access keys have been created yet, the same client routes continue to accept `Authorization: Bearer <password>`.
+- Admin and global credential management routes only accept the legacy Bearer password when `CODEBUDDY_PASSWORD` is configured.
 
 ## Configuration
 
 Settings resolve in this order: `config/config.json` > environment variables > built-in defaults.
 
-| Key                        | Default | Description                                           |
-| -------------------------- | ------- | ----------------------------------------------------- |
-| `CODEBUDDY_PASSWORD`       | empty   | Optional Bearer password for protected API routes.    |
-| `CODEBUDDY_AUTH_MODE`      | `auto`  | `auto`, `api_key`, or `token`.                        |
-| `CODEBUDDY_API_KEY`        | empty   | Required when `CODEBUDDY_AUTH_MODE=api_key`.          |
-| `CODEBUDDY_ROTATION_COUNT` | `1`     | Rotate credentials every N requests. `0` disables it. |
-| `CODEBUDDY_LOG_LEVEL`      | `INFO`  | Runtime log level.                                    |
+| Key                   | Default | Description                                                                |
+| --------------------- | ------- | -------------------------------------------------------------------------- |
+| `CODEBUDDY_PASSWORD`  | empty   | Optional legacy Bearer password for admin routes and access-key migration. |
+| `CODEBUDDY_AUTH_MODE` | `auto`  | `auto`, `api_key`, or `token`.                                             |
+| `CODEBUDDY_API_KEY`   | empty   | Required when `CODEBUDDY_AUTH_MODE=api_key`.                               |
+| `CODEBUDDY_LOG_LEVEL` | `INFO`  | Runtime log level.                                                         |
 
 See `.env.example` and `config/config.example.json` for all options.
 

--- a/app/admin-api/access-keys/[id]/route.ts
+++ b/app/admin-api/access-keys/[id]/route.ts
@@ -1,0 +1,79 @@
+import {
+  deleteAccessKey,
+  findAccessKeyById,
+  updateAccessKey,
+} from '@/lib/server/access-keys';
+import { listCredentialFilenames } from '@/lib/server/credentials';
+import { getJsonBody } from '@/lib/server/http';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const validateCredentialFilenames = (
+  credentialFilenames: unknown,
+): string[] => {
+  if (!Array.isArray(credentialFilenames)) {
+    throw new Error('credential_filenames must be an array');
+  }
+
+  const available = new Set(listCredentialFilenames());
+  const normalized = credentialFilenames
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (!normalized.length) {
+    throw new Error('At least one credential must be selected');
+  }
+
+  if (normalized.some((item) => !available.has(item))) {
+    throw new Error('Selected credentials must exist');
+  }
+
+  return normalized;
+};
+
+export const PATCH = async (
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> => {
+  const { id } = await context.params;
+  const body = await getJsonBody<{
+    credential_filenames?: unknown;
+    name?: unknown;
+  }>(request);
+
+  try {
+    const accessKey = updateAccessKey(id, {
+      credentialFilenames: validateCredentialFilenames(
+        body.credential_filenames,
+      ),
+      name: typeof body.name === 'string' ? body.name : '',
+    });
+
+    return Response.json({ access_key: accessKey });
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to update access key',
+      },
+      { status: findAccessKeyById(id) ? 400 : 404 },
+    );
+  }
+};
+
+export const DELETE = async (
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> => {
+  const { id } = await context.params;
+
+  if (!deleteAccessKey(id)) {
+    return Response.json({ error: 'Access key not found' }, { status: 404 });
+  }
+
+  return Response.json({ success: true });
+};

--- a/app/admin-api/access-keys/[id]/secret/route.ts
+++ b/app/admin-api/access-keys/[id]/secret/route.ts
@@ -1,0 +1,18 @@
+import { getAccessKeySecret } from '@/lib/server/access-keys';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export const GET = async (
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> => {
+  const { id } = await context.params;
+  const secret = getAccessKeySecret(id);
+
+  if (!secret) {
+    return Response.json({ error: 'Access key not found' }, { status: 404 });
+  }
+
+  return Response.json(secret);
+};

--- a/app/admin-api/access-keys/route.ts
+++ b/app/admin-api/access-keys/route.ts
@@ -1,0 +1,62 @@
+import { createAccessKey, listAccessKeys } from '@/lib/server/access-keys';
+import { listCredentialFilenames } from '@/lib/server/credentials';
+import { getJsonBody } from '@/lib/server/http';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const validateCredentialFilenames = (
+  credentialFilenames: unknown,
+): string[] => {
+  if (!Array.isArray(credentialFilenames)) {
+    throw new Error('credential_filenames must be an array');
+  }
+
+  const available = new Set(listCredentialFilenames());
+  const normalized = credentialFilenames
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (!normalized.length) {
+    throw new Error('At least one credential must be selected');
+  }
+
+  if (normalized.some((item) => !available.has(item))) {
+    throw new Error('Selected credentials must exist');
+  }
+
+  return normalized;
+};
+
+export const GET = async (): Promise<Response> => {
+  return Response.json(listAccessKeys());
+};
+
+export const POST = async (request: Request): Promise<Response> => {
+  const body = await getJsonBody<{
+    credential_filenames?: unknown;
+    name?: unknown;
+  }>(request);
+
+  try {
+    const created = createAccessKey({
+      credentialFilenames: validateCredentialFilenames(
+        body.credential_filenames,
+      ),
+      name: typeof body.name === 'string' ? body.name : '',
+    });
+
+    return Response.json(created);
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to create access key',
+      },
+      { status: 400 },
+    );
+  }
+};

--- a/app/admin/_components/admin-console.tsx
+++ b/app/admin/_components/admin-console.tsx
@@ -22,6 +22,7 @@ import {
   activeTabAtom,
   apiTestStateAtom,
   authStateAtom,
+  type AccessKeySummary,
   type CredentialSummary,
   credentialsStateAtom,
   dashboardStateAtom,
@@ -42,11 +43,21 @@ interface CredentialsResponse {
   credentials?: CredentialSummary[];
 }
 
+interface AccessKeysResponse {
+  access_keys?: AccessKeySummary[];
+}
+
+interface AccessKeySecretResponse {
+  id?: string;
+  name?: string;
+  secret?: string;
+}
+
 interface CurrentCredentialResponse {
-  auto_rotation_enabled?: boolean;
+  available_credential_count?: number;
   filename?: string;
   index?: number;
-  rotation_count?: number;
+  next_filename?: string | null;
   status?: string;
   user_id?: string;
 }
@@ -250,24 +261,30 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
   const loadCredentials = useCallback(async () => {
     setCredentials((current) => ({
       ...current,
+      accessKeysLoading: true,
       currentLoading: true,
       loading: true,
     }));
 
-    const [listResult, currentResult] = await Promise.all([
+    const [listResult, currentResult, accessKeyResult] = await Promise.all([
       requestJson<CredentialsResponse>('/admin-api/credentials'),
       requestJson<CurrentCredentialResponse>('/admin-api/credentials/current'),
+      requestJson<AccessKeysResponse>('/admin-api/access-keys'),
     ]);
 
     setCredentials((current) => ({
       ...current,
+      accessKeyActionId: null,
+      accessKeys: accessKeyResult.data?.access_keys ?? [],
+      accessKeysLoading: false,
       actionIndex: null,
       current: currentResult.data
         ? {
-            auto_rotation_enabled: currentResult.data.auto_rotation_enabled,
+            available_credential_count:
+              currentResult.data.available_credential_count,
             filename: currentResult.data.filename,
             index: currentResult.data.index,
-            rotation_count: currentResult.data.rotation_count,
+            next_filename: currentResult.data.next_filename,
             status: currentResult.data.status ?? 'no_credentials',
             user_id: currentResult.data.user_id,
           }
@@ -462,36 +479,6 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
     await refreshAdminData();
   };
 
-  const selectCredential = async (index: number) => {
-    setCredentials((current) => ({
-      ...current,
-      actionIndex: index,
-    }));
-
-    const result = await requestJson<{ success?: boolean }>(
-      '/admin-api/credentials/select',
-      {
-        body: JSON.stringify({ index }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'POST',
-      },
-    );
-
-    if (!result.ok || !result.data?.success) {
-      showNotification('error', getErrorMessage(result.data, '切换凭证失败。'));
-      setCredentials((current) => ({
-        ...current,
-        actionIndex: null,
-      }));
-      return;
-    }
-
-    showNotification('success', '当前凭证已切换。');
-    await refreshAdminData();
-  };
-
   const deleteCredential = async (index: number) => {
     setCredentials((current) => ({
       ...current,
@@ -522,49 +509,144 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
     await refreshAdminData();
   };
 
-  const toggleRotation = async () => {
-    const result = await requestJson<{ auto_rotation_enabled?: boolean }>(
-      '/admin-api/credentials/toggle-rotation',
-      {
-        method: 'POST',
+  const saveAccessKey = async () => {
+    const { credentialFilenames, editingId, name } = credentials.accessKeyForm;
+
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: editingId ?? '__new__',
+    }));
+
+    const endpoint = editingId
+      ? `/admin-api/access-keys/${editingId}`
+      : '/admin-api/access-keys';
+    const method = editingId ? 'PATCH' : 'POST';
+    const result = await requestJson<{
+      access_key?: AccessKeySummary;
+      secret?: string;
+    }>(endpoint, {
+      body: JSON.stringify({
+        credential_filenames: credentialFilenames,
+        name,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+      method,
+    });
 
     if (!result.ok) {
       showNotification(
         'error',
-        getErrorMessage(result.data, '更新轮换状态失败。'),
+        getErrorMessage(
+          result.data,
+          editingId ? '更新访问 key 失败。' : '创建访问 key 失败。',
+        ),
       );
+      setCredentials((current) => ({
+        ...current,
+        accessKeyActionId: null,
+      }));
       return;
     }
 
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: null,
+      accessKeyForm: {
+        credentialFilenames: [],
+        editingId: null,
+        name: '',
+      },
+      revealedSecret:
+        result.data?.access_key && result.data.secret
+          ? {
+              id: result.data.access_key.id,
+              name: result.data.access_key.name,
+              secret: result.data.secret,
+            }
+          : current.revealedSecret,
+    }));
     showNotification(
       'success',
-      result.data?.auto_rotation_enabled
-        ? '自动轮换已开启。'
-        : '自动轮换已暂停。',
+      editingId ? '访问 key 已更新。' : '访问 key 已生成。',
     );
     await loadCredentials();
   };
 
-  const resumeAutoRotation = async () => {
+  const deleteAccessKey = async (id: string) => {
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: id,
+    }));
+
     const result = await requestJson<{ success?: boolean }>(
-      '/admin-api/credentials/auto',
+      `/admin-api/access-keys/${id}`,
       {
-        method: 'POST',
+        method: 'DELETE',
       },
     );
 
     if (!result.ok || !result.data?.success) {
       showNotification(
         'error',
-        getErrorMessage(result.data, '恢复自动轮换失败。'),
+        getErrorMessage(result.data, '删除访问 key 失败。'),
       );
+      setCredentials((current) => ({
+        ...current,
+        accessKeyActionId: null,
+      }));
       return;
     }
 
-    showNotification('success', '自动轮换已恢复。');
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: null,
+      revealedSecret:
+        current.revealedSecret?.id === id ? null : current.revealedSecret,
+    }));
+    showNotification('success', '访问 key 已删除。');
     await loadCredentials();
+  };
+
+  const revealAccessKeySecret = async (id: string) => {
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: id,
+    }));
+
+    const result = await requestJson<AccessKeySecretResponse>(
+      `/admin-api/access-keys/${id}/secret`,
+    );
+
+    if (!result.ok || !result.data?.secret || !result.data?.name) {
+      showNotification(
+        'error',
+        getErrorMessage(result.data, '读取访问 key 失败。'),
+      );
+      setCredentials((current) => ({
+        ...current,
+        accessKeyActionId: null,
+      }));
+      return;
+    }
+
+    const secretPayload = result.data as {
+      id?: string;
+      name: string;
+      secret: string;
+    };
+
+    setCredentials((current) => ({
+      ...current,
+      accessKeyActionId: null,
+      revealedSecret: {
+        id: secretPayload.id ?? id,
+        name: secretPayload.name,
+        secret: secretPayload.secret,
+      },
+    }));
+    showNotification('success', '访问 key 已显示。');
   };
 
   const copyText = async (value: string, successMessage: string) => {
@@ -833,6 +915,19 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
               onDeleteCredential={(index) => {
                 void deleteCredential(index);
               }}
+              onDeleteAccessKey={(id) => {
+                void deleteAccessKey(id);
+              }}
+              onEditAccessKey={(accessKey) => {
+                setCredentials((current) => ({
+                  ...current,
+                  accessKeyForm: {
+                    credentialFilenames: [...accessKey.credentialFilenames],
+                    editingId: accessKey.id,
+                    name: accessKey.name,
+                  },
+                }));
+              }}
               onOpenAuthUrl={() => {
                 if (!auth.authUrl) {
                   showNotification('warning', '认证链接还未生成。');
@@ -847,11 +942,11 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
               onRefreshCredentials={() => {
                 void refreshAdminData();
               }}
-              onResumeAutoRotation={() => {
-                void resumeAutoRotation();
+              onRevealAccessKeySecret={(id) => {
+                void revealAccessKeySecret(id);
               }}
-              onSelectCredential={(index) => {
-                void selectCredential(index);
+              onSaveAccessKey={() => {
+                void saveAccessKey();
               }}
               onSubmitCallbackUrl={() => {
                 void submitCallbackUrl();
@@ -862,8 +957,47 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
                   showManualCallback: showManual,
                 }));
               }}
-              onToggleRotation={() => {
-                void toggleRotation();
+              onToggleCredentialSelection={(filename) => {
+                setCredentials((current) => {
+                  const selected =
+                    current.accessKeyForm.credentialFilenames.includes(
+                      filename,
+                    );
+
+                  return {
+                    ...current,
+                    accessKeyForm: {
+                      ...current.accessKeyForm,
+                      credentialFilenames: selected
+                        ? current.accessKeyForm.credentialFilenames.filter(
+                            (item) => item !== filename,
+                          )
+                        : [
+                            ...current.accessKeyForm.credentialFilenames,
+                            filename,
+                          ],
+                    },
+                  };
+                });
+              }}
+              onUpdateAccessKeyName={(value) => {
+                setCredentials((current) => ({
+                  ...current,
+                  accessKeyForm: {
+                    ...current.accessKeyForm,
+                    name: value,
+                  },
+                }));
+              }}
+              onResetAccessKeyForm={() => {
+                setCredentials((current) => ({
+                  ...current,
+                  accessKeyForm: {
+                    credentialFilenames: [],
+                    editingId: null,
+                    name: '',
+                  },
+                }));
               }}
             />
           ) : null}
@@ -904,10 +1038,7 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
                   ...current,
                   values: {
                     ...current.values,
-                    [key]:
-                      key === 'CODEBUDDY_ROTATION_COUNT'
-                        ? Number(value)
-                        : value,
+                    [key]: value,
                   },
                 }));
               }}

--- a/app/admin/_components/admin-console.tsx
+++ b/app/admin/_components/admin-console.tsx
@@ -32,6 +32,7 @@ import {
   notificationAtom,
   settingsStateAtom,
   themeAtom,
+  type ThemeMode,
 } from '@/app/admin/_components/admin-store';
 
 interface HealthResponse {
@@ -153,6 +154,22 @@ const buildApiEndpoint = () => {
   }
 
   return `${window.location.origin}/v1`;
+};
+
+const resolveSystemDark = () => {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return false;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+const resolveDarkMode = (theme: ThemeMode) => {
+  if (theme === 'system') {
+    return resolveSystemDark();
+  }
+
+  return theme === 'dark';
 };
 
 const formatResult = (payload: unknown) => {
@@ -803,7 +820,11 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
     );
     const storedTab = window.localStorage.getItem('codebuddy2api-admin-tab');
 
-    if (storedTheme === 'dark' || storedTheme === 'light') {
+    if (
+      storedTheme === 'dark' ||
+      storedTheme === 'light' ||
+      storedTheme === 'system'
+    ) {
       setTheme(storedTheme);
     }
 
@@ -818,8 +839,31 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
   }, [setActiveTab, setTheme]);
 
   useEffect(() => {
-    document.body.classList.toggle('dark', theme === 'dark');
+    const applyTheme = () => {
+      const isDark = resolveDarkMode(theme);
+
+      document.documentElement.classList.toggle('dark', isDark);
+      document.body.classList.toggle('dark', isDark);
+      document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+    };
+
+    applyTheme();
     window.localStorage.setItem('codebuddy2api-admin-theme', theme);
+
+    if (theme !== 'system' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => {
+      applyTheme();
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
   }, [theme]);
 
   useEffect(() => {
@@ -849,17 +893,29 @@ const AdminConsole = ({ initialData }: AdminConsoleProps) => {
             CodeBuddy2API 管理面板
           </h1>
           <div className="flex items-center gap-4">
-            <button
-              className="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark text-text-light dark:text-text-dark px-4 py-2 cursor-pointer transition-all hover:bg-bg-light hover:border-primary hover:text-primary dark:hover:bg-bg-dark"
-              onClick={() => {
-                setTheme(theme === 'dark' ? 'light' : 'dark');
-              }}
-            >
+            <label className="flex items-center gap-2 text-sm text-secondary">
               <i
-                className={theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon'}
-                id="themeIcon"
+                className={
+                  theme === 'dark'
+                    ? 'fas fa-moon'
+                    : theme === 'light'
+                      ? 'fas fa-sun'
+                      : 'fas fa-desktop'
+                }
               ></i>
-            </button>
+              <select
+                aria-label="Theme mode"
+                className="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark text-text-light dark:text-text-dark px-3 py-2 cursor-pointer transition-all hover:border-primary focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
+                value={theme}
+                onChange={(event) => {
+                  setTheme(event.target.value as ThemeMode);
+                }}
+              >
+                <option value="system">跟随系统</option>
+                <option value="light">浅色模式</option>
+                <option value="dark">暗黑模式</option>
+              </select>
+            </label>
           </div>
         </header>
         <main className="mt-20 px-8 py-8 max-w-[1400px] mx-auto">

--- a/app/admin/_components/admin-initial-state.ts
+++ b/app/admin/_components/admin-initial-state.ts
@@ -1,4 +1,5 @@
 import type {
+  AccessKeySummary,
   CredentialsState,
   CredentialSummary,
   CurrentCredentialInfo,
@@ -24,6 +25,7 @@ export interface AdminSettingsSnapshot {
 }
 
 export interface AdminConsoleInitialData {
+  accessKeys: AccessKeySummary[];
   apiEndpoint: string;
   credentials: CredentialSummary[];
   currentCredential: CurrentCredentialInfo;
@@ -71,6 +73,14 @@ export const createCredentialsState = (
   initialData: AdminConsoleInitialData,
 ): CredentialsState => {
   return {
+    accessKeyActionId: null,
+    accessKeyForm: {
+      credentialFilenames: [],
+      editingId: null,
+      name: '',
+    },
+    accessKeys: initialData.accessKeys,
+    accessKeysLoading: false,
     actionIndex: null,
     current: initialData.currentCredential,
     currentLoading: false,
@@ -80,6 +90,7 @@ export const createCredentialsState = (
     },
     items: initialData.credentials,
     loading: false,
+    revealedSecret: null,
   };
 };
 

--- a/app/admin/_components/admin-sections.tsx
+++ b/app/admin/_components/admin-sections.tsx
@@ -1,4 +1,5 @@
 import type {
+  AccessKeySummary,
   ApiTestState,
   AuthState,
   CredentialSummary,
@@ -36,14 +37,18 @@ interface CredentialsSectionProps {
   onCredentialTokenChange: (value: string) => void;
   onCredentialUserIdChange: (value: string) => void;
   onDeleteCredential: (index: number) => void;
+  onDeleteAccessKey: (id: string) => void;
+  onEditAccessKey: (accessKey: AccessKeySummary) => void;
   onOpenAuthUrl: () => void;
   onPollAuth: () => void;
   onRefreshCredentials: () => void;
-  onResumeAutoRotation: () => void;
-  onSelectCredential: (index: number) => void;
+  onResetAccessKeyForm: () => void;
+  onRevealAccessKeySecret: (id: string) => void;
+  onSaveAccessKey: () => void;
   onSubmitCallbackUrl: () => void;
   onToggleCallbackMode: (showManual: boolean) => void;
-  onToggleRotation: () => void;
+  onToggleCredentialSelection: (filename: string) => void;
+  onUpdateAccessKeyName: (value: string) => void;
 }
 
 interface ApiTestSectionProps {
@@ -81,17 +86,13 @@ const getCredentialBadge = (
   credential: CredentialSummary,
   current: CurrentCredentialInfo | null,
 ) => {
-  if (current?.index === credential.index) {
-    if (current.status === 'manual_selected') {
-      return {
-        className: 'px-3 py-1 text-xs font-medium bg-warning/10 text-warning',
-        label: '手动选中',
-      };
-    }
-
+  if (
+    current?.status === 'round_robin' &&
+    current.next_filename === credential.filename
+  ) {
     return {
       className: 'px-3 py-1 text-xs font-medium bg-success/10 text-success',
-      label: '当前使用中',
+      label: '下一次轮询',
     };
   }
 
@@ -140,11 +141,11 @@ const formatCurrentStatus = (current: CurrentCredentialInfo | null) => {
     return '当前没有可用凭证';
   }
 
-  if (current.status === 'manual_selected') {
-    return '当前处于手动选中模式';
+  if (current.status === 'access_keys_enabled') {
+    return '已启用访问 Keys，业务请求会在各自绑定的凭证子集里轮询。';
   }
 
-  return '当前处于自动轮换模式';
+  return '当前未配置访问 Keys，请求会在全局可用凭证之间轮询。';
 };
 
 const SettingsInput = ({
@@ -245,14 +246,7 @@ const SettingsInput = ({
       <input
         id={settingKey}
         className="w-full p-3 border border-border-light dark:border-border-dark bg-card-light dark:bg-card-dark text-text-light dark:text-text-dark focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
-        type={
-          settingKey === 'CODEBUDDY_PASSWORD' ||
-          settingKey === 'CODEBUDDY_API_KEY'
-            ? 'password'
-            : settingKey === 'CODEBUDDY_ROTATION_COUNT'
-              ? 'number'
-              : 'text'
-        }
+        type={settingKey === 'CODEBUDDY_API_KEY' ? 'password' : 'text'}
         value={value}
         onChange={(event) => {
           onChange(event.target.value);
@@ -266,12 +260,10 @@ const CredentialCard = ({
   credential,
   current,
   onDelete,
-  onSelect,
 }: {
   credential: CredentialSummary;
   current: CurrentCredentialInfo | null;
   onDelete: () => void;
-  onSelect: () => void;
 }) => {
   const badge = getCredentialBadge(credential, current);
   const avatarText = (credential.name ?? credential.email ?? credential.user_id)
@@ -311,13 +303,6 @@ const CredentialCard = ({
       </div>
       <div className="flex gap-2 shrink-0">
         <button
-          className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-primary text-white hover:bg-primary-dark"
-          onClick={onSelect}
-        >
-          <i className="fas fa-bullseye"></i>
-          设为当前
-        </button>
-        <button
           className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-error text-white hover:bg-error"
           onClick={onDelete}
         >
@@ -334,12 +319,10 @@ const CredentialGroup = ({
   items,
   title,
   onDelete,
-  onSelect,
 }: {
   current: CurrentCredentialInfo | null;
   items: CredentialSummary[];
   onDelete: (index: number) => void;
-  onSelect: (index: number) => void;
   title: string;
 }) => {
   if (!items.length) {
@@ -366,9 +349,6 @@ const CredentialGroup = ({
               current={current}
               onDelete={() => {
                 onDelete(credential.index);
-              }}
-              onSelect={() => {
-                onSelect(credential.index);
               }}
             />
           ))}
@@ -668,6 +648,81 @@ export const DashboardSection = ({
   );
 };
 
+const AccessKeyCard = ({
+  accessKey,
+  onDelete,
+  onEdit,
+  onRevealSecret,
+}: {
+  accessKey: AccessKeySummary;
+  onDelete: () => void;
+  onEdit: () => void;
+  onRevealSecret: () => void;
+}) => {
+  return (
+    <div className="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark p-5 transition-all relative hover:-translate-y-px hover:shadow-md hover:border-primary">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="font-semibold text-text-light dark:text-text-dark">
+              {accessKey.name}
+            </div>
+            <span className="px-3 py-1 text-xs font-medium bg-primary/10 text-primary">
+              {accessKey.credentialFilenames.length} 个凭证
+            </span>
+          </div>
+          <div className="font-mono text-sm text-secondary break-all">
+            {accessKey.maskedSecret}
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-secondary mt-3">
+            <span className="flex items-center gap-1">
+              <i className="fas fa-calendar"></i>
+              创建于 {new Date(accessKey.createdAt).toLocaleString('zh-CN')}
+            </span>
+            <span className="flex items-center gap-1">
+              <i className="fas fa-pen"></i>
+              更新于 {new Date(accessKey.updatedAt).toLocaleString('zh-CN')}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2 mt-3">
+            {accessKey.credentialFilenames.map((filename) => (
+              <span
+                key={filename}
+                className="px-2 py-1 text-xs bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark font-mono"
+              >
+                {filename}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <button
+            className="inline-flex items-center gap-2 px-4 py-2 border-none font-medium cursor-pointer transition-all text-sm bg-secondary text-white hover:bg-secondary"
+            onClick={onRevealSecret}
+          >
+            <i className="fas fa-eye"></i>
+            查看 Key
+          </button>
+          <button
+            className="inline-flex items-center gap-2 px-4 py-2 border-none font-medium cursor-pointer transition-all text-sm bg-primary text-white hover:bg-primary-dark"
+            onClick={onEdit}
+          >
+            <i className="fas fa-pen"></i>
+            编辑
+          </button>
+          <button
+            className="inline-flex items-center gap-2 px-4 py-2 border-none font-medium cursor-pointer transition-all text-sm bg-error text-white hover:bg-error"
+            onClick={onDelete}
+          >
+            <i className="fas fa-trash"></i>
+            删除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const CredentialsSection = ({
   auth,
   credentials,
@@ -678,24 +733,23 @@ export const CredentialsSection = ({
   onCredentialTokenChange,
   onCredentialUserIdChange,
   onDeleteCredential,
+  onDeleteAccessKey,
+  onEditAccessKey,
   onOpenAuthUrl,
   onPollAuth,
   onRefreshCredentials,
-  onResumeAutoRotation,
-  onSelectCredential,
+  onResetAccessKeyForm,
+  onRevealAccessKeySecret,
+  onSaveAccessKey,
   onSubmitCallbackUrl,
   onToggleCallbackMode,
-  onToggleRotation,
+  onToggleCredentialSelection,
+  onUpdateAccessKeyName,
 }: CredentialsSectionProps) => {
   const validCredentials = credentials.items.filter((item) => !item.is_expired);
   const expiredCredentials = credentials.items.filter(
     (item) => item.is_expired,
   );
-  const rotationEnabled =
-    credentials.current?.auto_rotation_enabled ??
-    (credentials.current
-      ? credentials.current.status !== 'no_credentials'
-      : false);
 
   return (
     <div id="credentials" className="block">
@@ -886,20 +940,15 @@ export const CredentialsSection = ({
       <div className="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark p-6 mb-6 shadow-sm transition-all">
         <div className="flex justify-between items-center mb-4 pb-4 border-b border-border-light dark:border-border-dark">
           <h3 className="text-lg font-semibold font-serif text-text-light dark:text-text-dark">
-            已保存的凭证
+            访问 Keys
           </h3>
           <div>
             <button
-              id="rotationToggleBtn"
               className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-secondary text-white hover:bg-secondary mr-2"
-              onClick={
-                rotationEnabled ? onToggleRotation : onResumeAutoRotation
-              }
+              onClick={onResetAccessKeyForm}
             >
-              <i
-                className={rotationEnabled ? 'fas fa-pause' : 'fas fa-play'}
-              ></i>
-              {rotationEnabled ? '暂停自动轮换' : '恢复自动轮换'}
+              <i className="fas fa-undo"></i>
+              重置表单
             </button>
             <button
               className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-primary text-white hover:bg-primary-dark"
@@ -911,8 +960,171 @@ export const CredentialsSection = ({
           </div>
         </div>
         <div
-          id="currentCredentialStatus"
+          id="accessKeyBuilder"
           className="flex justify-between items-center mb-4 pb-4 border-b border-border-light dark:border-border-dark"
+        >
+          <div className="w-full grid grid-cols-[minmax(0,1fr)_minmax(320px,420px)] gap-6 items-start">
+            <div>
+              <div className="font-semibold text-text-light dark:text-text-dark">
+                {credentials.accessKeyForm.editingId
+                  ? '编辑访问 Key'
+                  : '生成新的访问 Key'}
+              </div>
+              <div className="text-sm text-secondary mt-2">
+                secret
+                由服务端自动生成，用户只需要填写备注并绑定一个或多个凭证。
+              </div>
+              <div className="mt-4">
+                <label
+                  className="block mb-2 font-medium text-text-light dark:text-text-dark"
+                  htmlFor="accessKeyName"
+                >
+                  备注名
+                </label>
+                <input
+                  id="accessKeyName"
+                  className="w-full p-3 border border-border-light dark:border-border-dark bg-card-light dark:bg-card-dark text-text-light dark:text-text-dark focus:outline-none focus:border-primary focus:ring-3 focus:ring-primary/10"
+                  placeholder="例如：Claude Team / CI Runner"
+                  type="text"
+                  value={credentials.accessKeyForm.name}
+                  onChange={(event) => {
+                    onUpdateAccessKeyName(event.target.value);
+                  }}
+                />
+              </div>
+              <div className="mt-4">
+                <div className="block mb-2 font-medium text-text-light dark:text-text-dark">
+                  绑定凭证
+                </div>
+                <div className="grid gap-2 max-h-72 overflow-y-auto pr-1">
+                  {validCredentials.length ? (
+                    validCredentials.map((credential) => {
+                      const selected =
+                        credentials.accessKeyForm.credentialFilenames.includes(
+                          credential.filename,
+                        );
+
+                      return (
+                        <label
+                          key={credential.filename}
+                          className="flex items-center justify-between gap-4 p-3 border border-border-light dark:border-border-dark bg-bg-light dark:bg-bg-dark cursor-pointer"
+                        >
+                          <div className="min-w-0">
+                            <div className="font-medium text-text-light dark:text-text-dark">
+                              {credential.filename}
+                            </div>
+                            <div className="text-sm text-secondary">
+                              {credential.email || credential.user_id}
+                            </div>
+                          </div>
+                          <input
+                            checked={selected}
+                            type="checkbox"
+                            onChange={() => {
+                              onToggleCredentialSelection(credential.filename);
+                            }}
+                          />
+                        </label>
+                      );
+                    })
+                  ) : (
+                    <div className="text-sm text-secondary">
+                      还没有可绑定的有效凭证。
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="mt-4 flex gap-2">
+                <button
+                  className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-success text-white hover:bg-success"
+                  onClick={onSaveAccessKey}
+                >
+                  <i className="fas fa-key"></i>
+                  {credentials.accessKeyForm.editingId
+                    ? '保存访问 Key'
+                    : '生成访问 Key'}
+                </button>
+                <button
+                  className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-secondary text-white hover:bg-secondary"
+                  onClick={onResetAccessKeyForm}
+                >
+                  <i className="fas fa-times"></i>
+                  取消
+                </button>
+              </div>
+            </div>
+            <div className="p-4 bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark">
+              <div className="font-semibold text-text-light dark:text-text-dark">
+                最近查看的完整 Key
+              </div>
+              <div className="text-sm text-secondary mt-2">
+                列表中默认只展示掩码；点击“查看 Key”后，完整内容会显示在这里。
+              </div>
+              <div className="mt-4 p-3 border border-border-light dark:border-border-dark bg-card-light dark:bg-card-dark font-mono text-sm break-all min-h-[120px]">
+                {credentials.revealedSecret ? (
+                  <>
+                    <div className="mb-2 text-text-light dark:text-text-dark">
+                      {credentials.revealedSecret.name}
+                    </div>
+                    <div>{credentials.revealedSecret.secret}</div>
+                  </>
+                ) : (
+                  <div className="text-secondary">
+                    还没有查看过完整访问 key。
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="accessKeysList">
+          {credentials.accessKeysLoading ? (
+            <div className="text-center py-8 text-secondary">
+              <i className="fas fa-spinner fa-spin"></i>
+              <div>加载中...</div>
+            </div>
+          ) : credentials.accessKeys.length ? (
+            <div className="grid gap-3">
+              {credentials.accessKeys.map((accessKey) => (
+                <AccessKeyCard
+                  key={accessKey.id}
+                  accessKey={accessKey}
+                  onDelete={() => {
+                    onDeleteAccessKey(accessKey.id);
+                  }}
+                  onEdit={() => {
+                    onEditAccessKey(accessKey);
+                  }}
+                  onRevealSecret={() => {
+                    onRevealAccessKeySecret(accessKey.id);
+                  }}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-8 text-secondary">
+              <i className="fas fa-key"></i>
+              <div>还没有访问 key，生成后即可按 key 绑定凭证。</div>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark p-6 mb-6 shadow-sm transition-all">
+        <div className="flex justify-between items-center mb-4 pb-4 border-b border-border-light dark:border-border-dark">
+          <h3 className="text-lg font-semibold font-serif text-text-light dark:text-text-dark">
+            已保存的凭证
+          </h3>
+          <button
+            className="inline-flex items-center gap-2 px-6 py-3 border-none font-medium cursor-pointer transition-all text-sm bg-primary text-white hover:bg-primary-dark"
+            onClick={onRefreshCredentials}
+          >
+            <i className="fas fa-sync-alt"></i>
+            刷新列表
+          </button>
+        </div>
+        <div
+          id="currentCredentialStatus"
+          className="mb-4 pb-4 border-b border-border-light dark:border-border-dark"
         >
           {credentials.currentLoading ? (
             <div className="text-center py-8 text-secondary">
@@ -926,18 +1138,19 @@ export const CredentialsSection = ({
               </div>
               {credentials.current?.status !== 'no_credentials' ? (
                 <div className="flex flex-wrap gap-4 text-sm text-secondary mt-2">
-                  <span className="flex items-center gap-1">
-                    <i className="fas fa-file"></i>
-                    {credentials.current?.filename ?? 'Unknown'}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <i className="fas fa-user"></i>
-                    {credentials.current?.user_id ?? 'Unknown'}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <i className="fas fa-repeat"></i>
-                    轮换频率 {credentials.current?.rotation_count ?? 0}
-                  </span>
+                  {credentials.current?.next_filename ? (
+                    <span className="flex items-center gap-1">
+                      <i className="fas fa-file"></i>
+                      下一凭证 {credentials.current.next_filename}
+                    </span>
+                  ) : null}
+                  {credentials.current?.available_credential_count !==
+                  undefined ? (
+                    <span className="flex items-center gap-1">
+                      <i className="fas fa-layer-group"></i>
+                      可用凭证 {credentials.current.available_credential_count}
+                    </span>
+                  ) : null}
                 </div>
               ) : null}
             </div>
@@ -955,14 +1168,12 @@ export const CredentialsSection = ({
                 current={credentials.current}
                 items={validCredentials}
                 onDelete={onDeleteCredential}
-                onSelect={onSelectCredential}
                 title="可用凭证"
               />
               <CredentialGroup
                 current={credentials.current}
                 items={expiredCredentials}
                 onDelete={onDeleteCredential}
-                onSelect={onSelectCredential}
                 title="已过期凭证"
               />
             </>

--- a/app/admin/_components/admin-sections.tsx
+++ b/app/admin/_components/admin-sections.tsx
@@ -789,7 +789,7 @@ export const CredentialsSection = ({
           </p>
           <input
             id="authUrlInput"
-            className="w-full p-3 border border-border-light dark:border-border-dark bg-white dark:bg-card-dark font-mono text-sm mb-4 text-text-light dark:text-text-dark"
+            className="w-full p-3 border border-border-light dark:border-border-dark bg-card-light dark:bg-card-dark font-mono text-sm mb-4 text-text-light dark:text-text-dark"
             readOnly
             type="text"
             value={auth.authUrl}
@@ -1279,7 +1279,7 @@ export const ApiTestSection = ({
           </label>
           <div
             id="testResult"
-            className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm overflow-x-auto my-4 bg-bg-dark text-text-dark min-h-[200px]"
+            className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm text-text-light dark:text-text-dark overflow-x-auto my-4 min-h-[200px]"
           >
             <pre className="m-0 whitespace-pre-wrap">{state.result}</pre>
           </div>
@@ -1292,7 +1292,7 @@ export const ApiTestSection = ({
           </h3>
         </div>
         <h4 className="text-primary mb-4">curl 示例:</h4>
-        <div className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm overflow-x-auto my-4">{`curl -X POST "http://127.0.0.1:8001/v1/chat/completions" \\
+        <div className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm text-text-light dark:text-text-dark overflow-x-auto my-4">{`curl -X POST "http://127.0.0.1:8001/v1/chat/completions" \\
 -H "Authorization: Bearer YOUR_PASSWORD" \\
 -H "Content-Type: application/json" \\
 -d '{
@@ -1300,7 +1300,7 @@ export const ApiTestSection = ({
   "messages": [{ "role": "user", "content": "Hello!" }]
 }'`}</div>
         <h4 className="text-primary mt-6 mb-4">Python 示例:</h4>
-        <div className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm overflow-x-auto my-4">{`import openai
+        <div className="bg-bg-light dark:bg-bg-dark border border-border-light dark:border-border-dark p-4 font-mono text-sm text-text-light dark:text-text-dark overflow-x-auto my-4">{`import openai
 
 client = openai.OpenAI(
     api_key="YOUR_PASSWORD",

--- a/app/admin/_components/admin-store.ts
+++ b/app/admin/_components/admin-store.ts
@@ -30,17 +30,31 @@ export interface CredentialSummary {
   session_state: string | null;
 }
 
+export interface AccessKeySummary {
+  createdAt: string;
+  credentialFilenames: string[];
+  id: string;
+  maskedSecret: string;
+  name: string;
+  updatedAt: string;
+}
+
+export interface RevealedAccessKeySecret {
+  id: string;
+  name: string;
+  secret: string;
+}
+
 export interface CurrentCredentialInfo {
   status: string;
+  available_credential_count?: number;
   index?: number;
   filename?: string;
+  next_filename?: string | null;
   user_id?: string;
   domain?: string;
   enterprise_id?: string | number | null;
   tenant_id?: string | number | null;
-  usage_count?: number;
-  rotation_count?: number;
-  auto_rotation_enabled?: boolean;
 }
 
 export interface DashboardState {
@@ -75,13 +89,24 @@ export interface CredentialFormState {
   userId: string;
 }
 
+export interface AccessKeyFormState {
+  credentialFilenames: string[];
+  editingId: string | null;
+  name: string;
+}
+
 export interface CredentialsState {
+  accessKeyActionId: string | null;
+  accessKeyForm: AccessKeyFormState;
+  accessKeys: AccessKeySummary[];
+  accessKeysLoading: boolean;
   actionIndex: number | null;
   current: CurrentCredentialInfo | null;
   currentLoading: boolean;
   form: CredentialFormState;
   items: CredentialSummary[];
   loading: boolean;
+  revealedSecret: RevealedAccessKeySecret | null;
 }
 
 export interface ApiTestState {
@@ -179,6 +204,14 @@ export const defaultAuthState: AuthState = {
 export const authStateAtom = atom<AuthState>(defaultAuthState);
 
 export const defaultCredentialsState: CredentialsState = {
+  accessKeyActionId: null,
+  accessKeyForm: {
+    credentialFilenames: [],
+    editingId: null,
+    name: '',
+  },
+  accessKeys: [],
+  accessKeysLoading: true,
   actionIndex: null,
   current: null,
   currentLoading: true,
@@ -188,6 +221,7 @@ export const defaultCredentialsState: CredentialsState = {
   },
   items: [],
   loading: true,
+  revealedSecret: null,
 };
 
 export const credentialsStateAtom = atom<CredentialsState>(

--- a/app/admin/_components/admin-store.ts
+++ b/app/admin/_components/admin-store.ts
@@ -4,6 +4,8 @@ export type TabKey = 'dashboard' | 'credentials' | 'api-test' | 'settings';
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info';
 
+export type ThemeMode = 'light' | 'dark' | 'system';
+
 export interface NotificationState {
   message: string;
   type: NotificationType;
@@ -185,7 +187,7 @@ export const dashboardStateAtom = atom<DashboardState>(defaultDashboardState);
 
 export const activeTabAtom = atom<TabKey>('dashboard');
 
-export const themeAtom = atom<'light' | 'dark'>('light');
+export const themeAtom = atom<ThemeMode>('system');
 
 export const notificationAtom = atom<NotificationState | null>(null);
 

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import {
   getActiveConfig,
   SETTING_LABELS,
@@ -12,7 +12,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const GET = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;
@@ -25,7 +25,7 @@ export const GET = async (request: NextRequest): Promise<Response> => {
 };
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,11 @@ import { headers } from 'next/headers';
 
 import type { AdminConsoleInitialData } from '@/app/admin/_components/admin-initial-state';
 import AdminConsole from '@/app/admin/_components/admin-console';
-import type { CredentialSummary } from '@/app/admin/_components/admin-store';
+import type {
+  AccessKeySummary,
+  CredentialSummary,
+} from '@/app/admin/_components/admin-store';
+import { listAccessKeys } from '@/lib/server/access-keys';
 import { SETTING_LABELS, getActiveConfig } from '@/lib/server/config';
 import {
   getCurrentCredentialInfo,
@@ -27,6 +31,7 @@ const getInitialData = async (): Promise<AdminConsoleInitialData> => {
   const timestamp = new Date().toISOString();
 
   return {
+    accessKeys: listAccessKeys().access_keys as unknown as AccessKeySummary[],
     apiEndpoint: await buildApiEndpoint(),
     credentials: listCredentials()
       .credentials as unknown as CredentialSummary[],

--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getClientAuthErrorResponse } from '@/lib/server/auth';
 import { proxyChatCompletions } from '@/lib/server/codebuddy';
 import { getJsonBody } from '@/lib/server/http';
 
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getClientAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/auto/route.ts
+++ b/app/v1/credentials/auto/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { resumeAutoRotation } from '@/lib/server/credentials';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/current/route.ts
+++ b/app/v1/credentials/current/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { getCurrentCredentialInfo } from '@/lib/server/credentials';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const GET = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/delete/route.ts
+++ b/app/v1/credentials/delete/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { deleteCredentialByIndex } from '@/lib/server/credentials';
 import { createErrorResponse, getJsonBody } from '@/lib/server/http';
 
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/route.ts
+++ b/app/v1/credentials/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { addCredential, listCredentials } from '@/lib/server/credentials';
 import { getJsonBody } from '@/lib/server/http';
 
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const GET = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;
@@ -18,7 +18,7 @@ export const GET = async (request: NextRequest): Promise<Response> => {
 };
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/select/route.ts
+++ b/app/v1/credentials/select/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { selectCredential } from '@/lib/server/credentials';
 import { createErrorResponse, getJsonBody } from '@/lib/server/http';
 
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/credentials/toggle-rotation/route.ts
+++ b/app/v1/credentials/toggle-rotation/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getAdminAuthErrorResponse } from '@/lib/server/auth';
 import { toggleAutoRotation } from '@/lib/server/credentials';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getAdminAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/models/route.ts
+++ b/app/v1/models/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getClientAuthErrorResponse } from '@/lib/server/auth';
 import { getModelsResponse } from '@/lib/server/codebuddy';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const GET = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getClientAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/app/v1/responses/route.ts
+++ b/app/v1/responses/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from 'next/server';
 
-import { getAuthErrorResponse } from '@/lib/server/auth';
+import { getClientAuthErrorResponse } from '@/lib/server/auth';
 import { getJsonBody } from '@/lib/server/http';
 import { handleResponsesRequest } from '@/lib/server/responses';
 
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export const POST = async (request: NextRequest): Promise<Response> => {
-  const authError = getAuthErrorResponse(request);
+  const authError = getClientAuthErrorResponse(request);
 
   if (authError) {
     return authError;

--- a/deploy/k8s/codebuddy2api.yaml
+++ b/deploy/k8s/codebuddy2api.yaml
@@ -12,7 +12,6 @@ data:
   CODEBUDDY_INTERNET_ENVIRONMENT: 'ioa'
   CODEBUDDY_CREDS_DIR: '.codebuddy_creds'
   CODEBUDDY_LOG_LEVEL: 'INFO'
-  CODEBUDDY_ROTATION_COUNT: '1'
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/lib/server/access-keys.ts
+++ b/lib/server/access-keys.ts
@@ -1,0 +1,243 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { getConfigDir } from './config';
+
+export interface AccessKeyRecord {
+  createdAt: string;
+  credentialFilenames: string[];
+  id: string;
+  name: string;
+  secret: string;
+  updatedAt: string;
+}
+
+export interface AccessKeySummary {
+  createdAt: string;
+  credentialFilenames: string[];
+  id: string;
+  maskedSecret: string;
+  name: string;
+  updatedAt: string;
+}
+
+interface AccessKeyStore {
+  accessKeys: AccessKeyRecord[];
+}
+
+const getAccessKeysPath = (): string => {
+  return path.join(getConfigDir(), 'access-keys.json');
+};
+
+const ensureConfigDir = (): void => {
+  fs.mkdirSync(getConfigDir(), { recursive: true });
+};
+
+const readAccessKeyStore = (): AccessKeyStore => {
+  const filePath = getAccessKeysPath();
+
+  if (!fs.existsSync(filePath)) {
+    return { accessKeys: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(filePath, 'utf8'),
+    ) as Partial<AccessKeyStore>;
+    return {
+      accessKeys: Array.isArray(parsed.accessKeys)
+        ? parsed.accessKeys.filter((item): item is AccessKeyRecord => {
+            return Boolean(
+              item &&
+              typeof item === 'object' &&
+              typeof item.id === 'string' &&
+              typeof item.name === 'string' &&
+              typeof item.secret === 'string' &&
+              typeof item.createdAt === 'string' &&
+              typeof item.updatedAt === 'string' &&
+              Array.isArray(item.credentialFilenames),
+            );
+          })
+        : [],
+    };
+  } catch {
+    return { accessKeys: [] };
+  }
+};
+
+const writeAccessKeyStore = (store: AccessKeyStore): void => {
+  ensureConfigDir();
+  fs.writeFileSync(getAccessKeysPath(), JSON.stringify(store, null, 2));
+};
+
+const normalizeCredentialFilenames = (
+  credentialFilenames: string[],
+): string[] => {
+  return Array.from(
+    new Set(credentialFilenames.map((item) => item.trim()).filter(Boolean)),
+  ).sort((left, right) => left.localeCompare(right));
+};
+
+const maskSecret = (secret: string): string => {
+  if (secret.length <= 12) {
+    return `${secret.slice(0, 4)}****`;
+  }
+
+  return `${secret.slice(0, 8)}...${secret.slice(-4)}`;
+};
+
+const toSummary = (record: AccessKeyRecord): AccessKeySummary => {
+  return {
+    createdAt: record.createdAt,
+    credentialFilenames: [...record.credentialFilenames],
+    id: record.id,
+    maskedSecret: maskSecret(record.secret),
+    name: record.name,
+    updatedAt: record.updatedAt,
+  };
+};
+
+const generateSecret = (): string => {
+  return `cb2_${crypto.randomBytes(32).toString('base64url')}`;
+};
+
+export const hasAccessKeys = (): boolean => {
+  return readAccessKeyStore().accessKeys.length > 0;
+};
+
+export const listAccessKeys = (): { access_keys: AccessKeySummary[] } => {
+  return {
+    access_keys: readAccessKeyStore().accessKeys.map(toSummary),
+  };
+};
+
+export const listStoredAccessKeys = (): AccessKeyRecord[] => {
+  return readAccessKeyStore().accessKeys.map((item) => ({
+    ...item,
+    credentialFilenames: [...item.credentialFilenames],
+  }));
+};
+
+export const findAccessKeyById = (id: string): AccessKeyRecord | null => {
+  return readAccessKeyStore().accessKeys.find((item) => item.id === id) ?? null;
+};
+
+export const findAccessKeyBySecret = (
+  secret: string,
+): AccessKeyRecord | null => {
+  if (!secret.trim()) {
+    return null;
+  }
+
+  return (
+    readAccessKeyStore().accessKeys.find((item) => item.secret === secret) ??
+    null
+  );
+};
+
+export const createAccessKey = ({
+  credentialFilenames,
+  name,
+}: {
+  credentialFilenames: string[];
+  name: string;
+}): {
+  access_key: AccessKeySummary;
+  secret: string;
+} => {
+  const trimmedName = name.trim();
+  const normalizedCredentialFilenames =
+    normalizeCredentialFilenames(credentialFilenames);
+
+  if (!trimmedName) {
+    throw new Error('Access key name is required');
+  }
+
+  if (!normalizedCredentialFilenames.length) {
+    throw new Error('At least one credential must be selected');
+  }
+
+  const now = new Date().toISOString();
+  const record: AccessKeyRecord = {
+    createdAt: now,
+    credentialFilenames: normalizedCredentialFilenames,
+    id: crypto.randomUUID(),
+    name: trimmedName,
+    secret: generateSecret(),
+    updatedAt: now,
+  };
+  const store = readAccessKeyStore();
+  store.accessKeys.push(record);
+  writeAccessKeyStore(store);
+
+  return {
+    access_key: toSummary(record),
+    secret: record.secret,
+  };
+};
+
+export const updateAccessKey = (
+  id: string,
+  {
+    credentialFilenames,
+    name,
+  }: {
+    credentialFilenames: string[];
+    name: string;
+  },
+): AccessKeySummary => {
+  const trimmedName = name.trim();
+  const normalizedCredentialFilenames =
+    normalizeCredentialFilenames(credentialFilenames);
+
+  if (!trimmedName) {
+    throw new Error('Access key name is required');
+  }
+
+  if (!normalizedCredentialFilenames.length) {
+    throw new Error('At least one credential must be selected');
+  }
+
+  const store = readAccessKeyStore();
+  const target = store.accessKeys.find((item) => item.id === id);
+
+  if (!target) {
+    throw new Error('Access key not found');
+  }
+
+  target.name = trimmedName;
+  target.credentialFilenames = normalizedCredentialFilenames;
+  target.updatedAt = new Date().toISOString();
+  writeAccessKeyStore(store);
+
+  return toSummary(target);
+};
+
+export const deleteAccessKey = (id: string): boolean => {
+  const store = readAccessKeyStore();
+  const nextAccessKeys = store.accessKeys.filter((item) => item.id !== id);
+
+  if (nextAccessKeys.length === store.accessKeys.length) {
+    return false;
+  }
+
+  writeAccessKeyStore({ accessKeys: nextAccessKeys });
+  return true;
+};
+
+export const getAccessKeySecret = (
+  id: string,
+): { id: string; name: string; secret: string } | null => {
+  const target = findAccessKeyById(id);
+
+  if (!target) {
+    return null;
+  }
+
+  return {
+    id: target.id,
+    name: target.name,
+    secret: target.secret,
+  };
+};

--- a/lib/server/access-keys.ts
+++ b/lib/server/access-keys.ts
@@ -26,6 +26,11 @@ interface AccessKeyStore {
   accessKeys: AccessKeyRecord[];
 }
 
+type AccessKeyStoreState =
+  | { kind: 'ok'; store: AccessKeyStore }
+  | { kind: 'missing'; store: AccessKeyStore }
+  | { kind: 'error'; error: string; store: AccessKeyStore };
+
 const getAccessKeysPath = (): string => {
   return path.join(getConfigDir(), 'access-keys.json');
 };
@@ -34,36 +39,50 @@ const ensureConfigDir = (): void => {
   fs.mkdirSync(getConfigDir(), { recursive: true });
 };
 
-const readAccessKeyStore = (): AccessKeyStore => {
+const readAccessKeyStoreState = (): AccessKeyStoreState => {
   const filePath = getAccessKeysPath();
 
   if (!fs.existsSync(filePath)) {
-    return { accessKeys: [] };
+    return { kind: 'missing', store: { accessKeys: [] } };
   }
 
   try {
     const parsed = JSON.parse(
       fs.readFileSync(filePath, 'utf8'),
     ) as Partial<AccessKeyStore>;
+    const accessKeys = Array.isArray(parsed.accessKeys)
+      ? parsed.accessKeys.filter((item): item is AccessKeyRecord => {
+          return Boolean(
+            item &&
+            typeof item === 'object' &&
+            typeof item.id === 'string' &&
+            typeof item.name === 'string' &&
+            typeof item.secret === 'string' &&
+            typeof item.createdAt === 'string' &&
+            typeof item.updatedAt === 'string' &&
+            Array.isArray(item.credentialFilenames),
+          );
+        })
+      : [];
+
     return {
-      accessKeys: Array.isArray(parsed.accessKeys)
-        ? parsed.accessKeys.filter((item): item is AccessKeyRecord => {
-            return Boolean(
-              item &&
-              typeof item === 'object' &&
-              typeof item.id === 'string' &&
-              typeof item.name === 'string' &&
-              typeof item.secret === 'string' &&
-              typeof item.createdAt === 'string' &&
-              typeof item.updatedAt === 'string' &&
-              Array.isArray(item.credentialFilenames),
-            );
-          })
-        : [],
+      kind: 'ok',
+      store: { accessKeys },
     };
-  } catch {
-    return { accessKeys: [] };
+  } catch (error) {
+    return {
+      kind: 'error',
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to read access key store',
+      store: { accessKeys: [] },
+    };
   }
+};
+
+const readAccessKeyStore = (): AccessKeyStore => {
+  return readAccessKeyStoreState().store;
 };
 
 const writeAccessKeyStore = (store: AccessKeyStore): void => {
@@ -104,6 +123,11 @@ const generateSecret = (): string => {
 
 export const hasAccessKeys = (): boolean => {
   return readAccessKeyStore().accessKeys.length > 0;
+};
+
+export const getAccessKeyStoreError = (): string | null => {
+  const state = readAccessKeyStoreState();
+  return state.kind === 'error' ? state.error : null;
 };
 
 export const listAccessKeys = (): { access_keys: AccessKeySummary[] } => {

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -1,6 +1,10 @@
 import type { NextRequest } from 'next/server';
 
-import { getServerPassword } from './config';
+import {
+  findAccessKeyBySecret,
+  hasAccessKeys,
+  type AccessKeyRecord,
+} from './access-keys';
 
 const extractBearerToken = (request: NextRequest): string | null => {
   const header = request.headers.get('authorization')?.trim();
@@ -18,30 +22,47 @@ const extractBearerToken = (request: NextRequest): string | null => {
   return token;
 };
 
-// Anthropic SDK and Claude Code send the API key via the x-api-key header.
 const extractApiKeyToken = (request: NextRequest): string | null => {
   return request.headers.get('x-api-key')?.trim() || null;
 };
 
-export const getAuthErrorResponse = (request: NextRequest): Response | null => {
-  const password = getServerPassword();
+const extractAccessKeyToken = (request: NextRequest): string | null => {
+  return extractBearerToken(request) ?? extractApiKeyToken(request);
+};
 
-  if (!password) {
+export const resolveRequestAccessKey = (
+  request: NextRequest,
+): AccessKeyRecord | null => {
+  if (!hasAccessKeys()) {
     return null;
   }
 
-  const token = extractBearerToken(request);
+  const token = extractAccessKeyToken(request);
+
+  if (!token) {
+    return null;
+  }
+
+  return findAccessKeyBySecret(token);
+};
+
+export const getAuthErrorResponse = (request: NextRequest): Response | null => {
+  if (!hasAccessKeys()) {
+    return null;
+  }
+
+  const token = extractAccessKeyToken(request);
 
   if (!token) {
     return Response.json(
-      { error: { message: 'Authorization header is required' } },
+      { error: { message: 'x-api-key or Authorization header is required' } },
       { status: 401 },
     );
   }
 
-  if (token !== password) {
+  if (!findAccessKeyBySecret(token)) {
     return Response.json(
-      { error: { message: 'Invalid password' } },
+      { error: { message: 'Invalid access key' } },
       { status: 403 },
     );
   }
@@ -49,19 +70,14 @@ export const getAuthErrorResponse = (request: NextRequest): Response | null => {
   return null;
 };
 
-// Anthropic SDK and Claude Code send the API key via the x-api-key header
-// instead of Authorization: Bearer. This function accepts both schemes so
-// /v1/messages works when CODEBUDDY_PASSWORD is configured.
 export const getAnthropicAuthErrorResponse = (
   request: NextRequest,
 ): Response | null => {
-  const password = getServerPassword();
-
-  if (!password) {
+  if (!hasAccessKeys()) {
     return null;
   }
 
-  const token = extractBearerToken(request) ?? extractApiKeyToken(request);
+  const token = extractAccessKeyToken(request);
 
   if (!token) {
     return Response.json(
@@ -76,7 +92,7 @@ export const getAnthropicAuthErrorResponse = (
     );
   }
 
-  if (token !== password) {
+  if (!findAccessKeyBySecret(token)) {
     return Response.json(
       {
         type: 'error',

--- a/lib/server/auth.ts
+++ b/lib/server/auth.ts
@@ -2,9 +2,11 @@ import type { NextRequest } from 'next/server';
 
 import {
   findAccessKeyBySecret,
+  getAccessKeyStoreError,
   hasAccessKeys,
   type AccessKeyRecord,
 } from './access-keys';
+import { getLegacyServerPassword } from './config';
 
 const extractBearerToken = (request: NextRequest): string | null => {
   const header = request.headers.get('authorization')?.trim();
@@ -30,9 +32,40 @@ const extractAccessKeyToken = (request: NextRequest): string | null => {
   return extractBearerToken(request) ?? extractApiKeyToken(request);
 };
 
+const getAccessKeyStoreErrorResponse = (): Response | null => {
+  if (!getAccessKeyStoreError()) {
+    return null;
+  }
+
+  return Response.json(
+    {
+      error: {
+        message:
+          'Access key storage is unreadable. Fix access-keys.json first.',
+      },
+    },
+    { status: 503 },
+  );
+};
+
+const getLegacyPasswordToken = (request: NextRequest): string | null => {
+  return extractBearerToken(request);
+};
+
+const matchesLegacyPassword = (request: NextRequest): boolean => {
+  const password = getLegacyServerPassword();
+  const token = getLegacyPasswordToken(request);
+
+  return Boolean(password && token && token === password);
+};
+
 export const resolveRequestAccessKey = (
   request: NextRequest,
 ): AccessKeyRecord | null => {
+  if (getAccessKeyStoreError()) {
+    return null;
+  }
+
   if (!hasAccessKeys()) {
     return null;
   }
@@ -46,8 +79,38 @@ export const resolveRequestAccessKey = (
   return findAccessKeyBySecret(token);
 };
 
-export const getAuthErrorResponse = (request: NextRequest): Response | null => {
+export const getClientAuthErrorResponse = (
+  request: NextRequest,
+): Response | null => {
+  const storeError = getAccessKeyStoreErrorResponse();
+
+  if (storeError) {
+    return storeError;
+  }
+
+  const legacyPassword = getLegacyServerPassword();
+
   if (!hasAccessKeys()) {
+    if (!legacyPassword) {
+      return null;
+    }
+
+    const token = getLegacyPasswordToken(request);
+
+    if (!token) {
+      return Response.json(
+        { error: { message: 'Authorization header is required' } },
+        { status: 401 },
+      );
+    }
+
+    if (token !== legacyPassword) {
+      return Response.json(
+        { error: { message: 'Invalid password' } },
+        { status: 403 },
+      );
+    }
+
     return null;
   }
 
@@ -60,6 +123,10 @@ export const getAuthErrorResponse = (request: NextRequest): Response | null => {
     );
   }
 
+  if (matchesLegacyPassword(request)) {
+    return null;
+  }
+
   if (!findAccessKeyBySecret(token)) {
     return Response.json(
       { error: { message: 'Invalid access key' } },
@@ -70,10 +137,91 @@ export const getAuthErrorResponse = (request: NextRequest): Response | null => {
   return null;
 };
 
+export const getAdminAuthErrorResponse = (
+  request: NextRequest,
+): Response | null => {
+  const storeError = getAccessKeyStoreErrorResponse();
+
+  if (storeError) {
+    return storeError;
+  }
+
+  const password = getLegacyServerPassword();
+
+  if (!password) {
+    return null;
+  }
+
+  const token = getLegacyPasswordToken(request);
+
+  if (!token) {
+    return Response.json(
+      { error: { message: 'Authorization header is required' } },
+      { status: 401 },
+    );
+  }
+
+  if (token !== password) {
+    return Response.json(
+      { error: { message: 'Invalid password' } },
+      { status: 403 },
+    );
+  }
+
+  return null;
+};
+
 export const getAnthropicAuthErrorResponse = (
   request: NextRequest,
 ): Response | null => {
+  const storeError = getAccessKeyStoreErrorResponse();
+
+  if (storeError) {
+    return Response.json(
+      {
+        type: 'error',
+        error: {
+          type: 'authentication_error',
+          message:
+            'Access key storage is unreadable. Fix access-keys.json first.',
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  const legacyPassword = getLegacyServerPassword();
+
   if (!hasAccessKeys()) {
+    if (!legacyPassword) {
+      return null;
+    }
+
+    const token = getLegacyPasswordToken(request);
+
+    if (!token) {
+      return Response.json(
+        {
+          type: 'error',
+          error: {
+            type: 'authentication_error',
+            message: 'Authorization header is required',
+          },
+        },
+        { status: 401 },
+      );
+    }
+
+    if (token !== legacyPassword) {
+      return Response.json(
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'Invalid API key' },
+        },
+        { status: 403 },
+      );
+    }
+
     return null;
   }
 
@@ -90,6 +238,10 @@ export const getAnthropicAuthErrorResponse = (
       },
       { status: 401 },
     );
+  }
+
+  if (matchesLegacyPassword(request)) {
+    return null;
   }
 
   if (!findAccessKeyBySecret(token)) {

--- a/lib/server/codebuddy.ts
+++ b/lib/server/codebuddy.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from 'next/server';
 
+import { resolveRequestAccessKey } from './auth';
 import {
   getActiveConfig,
   getAvailableModels,
@@ -108,7 +109,7 @@ const normalizeMessages = (messages: OpenAIMessage[]): OpenAIMessage[] => {
   return filtered;
 };
 
-const getResolvedAuth = (): ResolvedAuth => {
+const getResolvedAuth = (request: NextRequest): ResolvedAuth => {
   const config = getActiveConfig();
   const mode = config.CODEBUDDY_AUTH_MODE;
   const apiKey = config.CODEBUDDY_API_KEY?.trim();
@@ -125,7 +126,11 @@ const getResolvedAuth = (): ResolvedAuth => {
     };
   }
 
-  const credential = resolveCredentialForRequest();
+  const accessKey = resolveRequestAccessKey(request);
+  const credential = resolveCredentialForRequest({
+    accessKeyId: accessKey?.id,
+    allowedCredentialFilenames: accessKey?.credentialFilenames,
+  });
 
   if (!credential) {
     throw new Error('No valid CodeBuddy credentials found');
@@ -680,7 +685,7 @@ export const proxyChatCompletions = async (
   }
 
   try {
-    const auth = getResolvedAuth();
+    const auth = getResolvedAuth(request);
     const upstreamBody = buildUpstreamBody(body);
     const upstreamResponse = await fetch(
       `${getCodeBuddyApiEndpoint()}/v2/chat/completions`,

--- a/lib/server/config.ts
+++ b/lib/server/config.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 export interface RuntimeConfig {
-  CODEBUDDY_PASSWORD: string | null;
   CODEBUDDY_API_ENDPOINT: string;
   CODEBUDDY_AUTH_MODE: 'auto' | 'api_key' | 'token';
   CODEBUDDY_API_KEY: string | null;
@@ -10,10 +9,9 @@ export interface RuntimeConfig {
   CODEBUDDY_CREDS_DIR: string;
   CODEBUDDY_LOG_LEVEL: string;
   CODEBUDDY_MODELS: string;
-  CODEBUDDY_ROTATION_COUNT: number;
 }
 
-const getConfigPath = (): string => {
+export const getConfigPath = (): string => {
   return process.env.CODEBUDDY_CONFIG_PATH
     ? path.resolve(
         /* turbopackIgnore: true */ process.cwd(),
@@ -26,8 +24,11 @@ const getConfigPath = (): string => {
       );
 };
 
+export const getConfigDir = (): string => {
+  return path.dirname(getConfigPath());
+};
+
 const DEFAULT_CONFIG: RuntimeConfig = {
-  CODEBUDDY_PASSWORD: null,
   CODEBUDDY_API_ENDPOINT: 'https://copilot.tencent.com',
   CODEBUDDY_AUTH_MODE: 'auto',
   CODEBUDDY_API_KEY: null,
@@ -36,11 +37,9 @@ const DEFAULT_CONFIG: RuntimeConfig = {
   CODEBUDDY_LOG_LEVEL: 'INFO',
   CODEBUDDY_MODELS:
     'glm-5.1,glm-5.0,glm-5.0-turbo,glm-5v-turbo,glm-4.7,minimax-m3-play,minimax-m2.7,minimax-m2.5,kimi-k2.6,kimi-k2.5,hy3-preview-agent,deepseek-v4-pro,deepseek-v4-flash,deepseek-v3-2-volc,claude-sonnet-4.6,claude-opus-4.8,claude-opus-4.8-1m,claude-opus-4.7,claude-opus-4.7-1m,claude-opus-4.6,claude-opus-4.6-1m,claude-haiku-4.5,gemini-3.1-pro,gemini-3.5-flash,gemini-2.5-pro,gpt-5.5,gpt-5.4,gpt-5.3-codex,gpt-5.1-codex,gpt-5.1-codex-mini,glm-5.2-ioa,glm-5v-turbo-ioa,glm-5.0-ioa,glm-4.7-ioa,minimax-m3-ioa,minimax-m2.7-ioa,minimax-m2.5-ioa,kimi-k2.6-ioa,hy3-preview-agent-ioa,deepseek-v4-pro-ioa,deepseek-v4-flash-ioa,deepseek-v3-2-volc-ioa',
-  CODEBUDDY_ROTATION_COUNT: 1,
 };
 
 export const SETTING_LABELS: Record<keyof RuntimeConfig, string> = {
-  CODEBUDDY_PASSWORD: 'API 服务访问密码',
   CODEBUDDY_API_ENDPOINT: 'CodeBuddy 官方API端点',
   CODEBUDDY_AUTH_MODE: '认证模式 (auto/api_key/token)',
   CODEBUDDY_API_KEY: 'CodeBuddy API Key',
@@ -48,7 +47,6 @@ export const SETTING_LABELS: Record<keyof RuntimeConfig, string> = {
   CODEBUDDY_CREDS_DIR: '凭证文件目录',
   CODEBUDDY_LOG_LEVEL: '日志级别',
   CODEBUDDY_MODELS: '可用模型列表 (逗号分隔)',
-  CODEBUDDY_ROTATION_COUNT: '凭证轮换频率 (N次请求/凭证，设为0关闭轮换)',
 };
 
 const loadPersistedConfig = (): Partial<RuntimeConfig> => {
@@ -79,14 +77,13 @@ const normalizeValue = <K extends keyof RuntimeConfig>(
     return fallback;
   }
 
-  const nullableStringKeys: Array<keyof RuntimeConfig> = [
-    'CODEBUDDY_PASSWORD',
-    'CODEBUDDY_API_KEY',
-  ];
+  const nullableStringKeys: Array<keyof RuntimeConfig> = ['CODEBUDDY_API_KEY'];
 
   if (typeof fallback === 'number') {
     const parsed = Number(value);
-    return Number.isFinite(parsed) ? (parsed as RuntimeConfig[K]) : fallback;
+    return Number.isFinite(parsed)
+      ? (parsed as unknown as RuntimeConfig[K])
+      : fallback;
   }
 
   if (typeof fallback === 'string') {
@@ -104,10 +101,6 @@ export const getActiveConfig = (): RuntimeConfig => {
   const persisted = loadPersistedConfig();
 
   return {
-    CODEBUDDY_PASSWORD: normalizeValue(
-      'CODEBUDDY_PASSWORD',
-      persisted.CODEBUDDY_PASSWORD ?? process.env.CODEBUDDY_PASSWORD ?? null,
-    ),
     CODEBUDDY_API_ENDPOINT: normalizeValue(
       'CODEBUDDY_API_ENDPOINT',
       persisted.CODEBUDDY_API_ENDPOINT ?? process.env.CODEBUDDY_API_ENDPOINT,
@@ -136,11 +129,6 @@ export const getActiveConfig = (): RuntimeConfig => {
     CODEBUDDY_MODELS: normalizeValue(
       'CODEBUDDY_MODELS',
       persisted.CODEBUDDY_MODELS ?? process.env.CODEBUDDY_MODELS,
-    ),
-    CODEBUDDY_ROTATION_COUNT: normalizeValue(
-      'CODEBUDDY_ROTATION_COUNT',
-      persisted.CODEBUDDY_ROTATION_COUNT ??
-        process.env.CODEBUDDY_ROTATION_COUNT,
     ),
   };
 };
@@ -190,15 +178,6 @@ export const getAvailableModels = (): string[] => {
     .CODEBUDDY_MODELS.split(',')
     .map((item) => item.trim())
     .filter(Boolean);
-};
-
-export const getRotationCount = (): number => {
-  return getActiveConfig().CODEBUDDY_ROTATION_COUNT;
-};
-
-export const getServerPassword = (): string | null => {
-  const password = getActiveConfig().CODEBUDDY_PASSWORD?.trim();
-  return password ? password : null;
 };
 
 export const getCredsDir = (): string => {

--- a/lib/server/config.ts
+++ b/lib/server/config.ts
@@ -11,6 +11,10 @@ export interface RuntimeConfig {
   CODEBUDDY_MODELS: string;
 }
 
+interface PersistedConfigFile extends Partial<RuntimeConfig> {
+  CODEBUDDY_PASSWORD?: unknown;
+}
+
 export const getConfigPath = (): string => {
   return process.env.CODEBUDDY_CONFIG_PATH
     ? path.resolve(
@@ -49,7 +53,7 @@ export const SETTING_LABELS: Record<keyof RuntimeConfig, string> = {
   CODEBUDDY_MODELS: '可用模型列表 (逗号分隔)',
 };
 
-const loadPersistedConfig = (): Partial<RuntimeConfig> => {
+const loadPersistedConfigFile = (): PersistedConfigFile => {
   if (!fs.existsSync(getConfigPath())) {
     return {};
   }
@@ -61,10 +65,14 @@ const loadPersistedConfig = (): Partial<RuntimeConfig> => {
       return {};
     }
 
-    return JSON.parse(content) as Partial<RuntimeConfig>;
+    return JSON.parse(content) as PersistedConfigFile;
   } catch {
     return {};
   }
+};
+
+const loadPersistedConfig = (): Partial<RuntimeConfig> => {
+  return loadPersistedConfigFile();
 };
 
 const normalizeValue = <K extends keyof RuntimeConfig>(
@@ -124,6 +132,21 @@ export const getActiveConfig = (): RuntimeConfig => {
       persisted.CODEBUDDY_MODELS ?? process.env.CODEBUDDY_MODELS,
     ),
   };
+};
+
+export const getLegacyServerPassword = (): string | null => {
+  const persisted = loadPersistedConfigFile().CODEBUDDY_PASSWORD;
+  const password =
+    typeof persisted === 'string' && persisted.trim()
+      ? persisted
+      : process.env.CODEBUDDY_PASSWORD;
+
+  if (typeof password !== 'string') {
+    return null;
+  }
+
+  const trimmed = password.trim();
+  return trimmed ? trimmed : null;
 };
 
 export const updateSettings = (

--- a/lib/server/config.ts
+++ b/lib/server/config.ts
@@ -79,13 +79,6 @@ const normalizeValue = <K extends keyof RuntimeConfig>(
 
   const nullableStringKeys: Array<keyof RuntimeConfig> = ['CODEBUDDY_API_KEY'];
 
-  if (typeof fallback === 'number') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed)
-      ? (parsed as unknown as RuntimeConfig[K])
-      : fallback;
-  }
-
   if (typeof fallback === 'string') {
     return String(value) as RuntimeConfig[K];
   }

--- a/lib/server/credentials.ts
+++ b/lib/server/credentials.ts
@@ -1,38 +1,37 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { getCredsDir, getRotationCount } from './config';
+import { hasAccessKeys } from './access-keys';
+import { getCredsDir } from './config';
 import { recordCredentialUsage } from './stats';
 
 export type CredentialData = Record<string, unknown> & {
-  bearer_token?: string;
   access_token?: string;
-  user_id?: string;
+  bearer_token?: string;
   created_at?: number;
-  expires_in?: number;
-  refresh_token?: string;
-  token_type?: string;
-  scope?: string;
   domain?: string;
-  session_state?: string;
   enterprise_id?: string;
   enterpriseId?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+  session_state?: string;
   tenant_id?: string;
   tenantId?: string;
+  token_type?: string;
+  user_id?: string;
   user_info?: Record<string, unknown>;
 };
 
-interface CredentialRecord {
-  filename: string;
-  filePath: string;
+export interface CredentialRecord {
   data: CredentialData;
+  filePath: string;
+  filename: string;
 }
 
 interface ManagerState {
-  currentIndex: number;
-  usageCount: number;
-  manualSelectedIndex: number | null;
-  autoRotationEnabled: boolean;
+  globalNextFilename: string | null;
+  keyNextFilenameByAccessKeyId: Record<string, string | null>;
 }
 
 const globalCredentialState = globalThis as typeof globalThis & {
@@ -67,10 +66,9 @@ const getRuntimeState = (): ManagerState => {
   if (!globalCredentialState.__codebuddy2apiCredentialState__) {
     const persisted = loadPersistedManagerState();
     globalCredentialState.__codebuddy2apiCredentialState__ = {
-      currentIndex: persisted.currentIndex ?? 0,
-      usageCount: 0,
-      manualSelectedIndex: persisted.manualSelectedIndex ?? null,
-      autoRotationEnabled: persisted.autoRotationEnabled ?? true,
+      globalNextFilename: persisted.globalNextFilename ?? null,
+      keyNextFilenameByAccessKeyId:
+        persisted.keyNextFilenameByAccessKeyId ?? {},
     };
   }
 
@@ -81,14 +79,18 @@ const saveRuntimeState = (): void => {
   ensureCredsDir();
 
   const state = getRuntimeState();
-  const payload = {
-    autoRotationEnabled: state.autoRotationEnabled,
-    currentIndex: state.currentIndex,
-    manualSelectedIndex: state.manualSelectedIndex,
-    savedAt: Math.floor(Date.now() / 1000),
-  };
-
-  fs.writeFileSync(getManagerStateFile(), JSON.stringify(payload, null, 2));
+  fs.writeFileSync(
+    getManagerStateFile(),
+    JSON.stringify(
+      {
+        globalNextFilename: state.globalNextFilename,
+        keyNextFilenameByAccessKeyId: state.keyNextFilenameByAccessKeyId,
+        savedAt: Math.floor(Date.now() / 1000),
+      },
+      null,
+      2,
+    ),
+  );
 };
 
 const getNestedValue = (
@@ -132,7 +134,7 @@ const getNestedValue = (
   return null;
 };
 
-const readCredentialRecords = (): CredentialRecord[] => {
+export const readCredentialRecords = (): CredentialRecord[] => {
   ensureCredsDir();
 
   return fs
@@ -152,11 +154,15 @@ const readCredentialRecords = (): CredentialRecord[] => {
           return [];
         }
 
-        return [{ filename, filePath, data }];
+        return [{ data, filePath, filename }];
       } catch {
         return [];
       }
     });
+};
+
+export const listCredentialFilenames = (): string[] => {
+  return readCredentialRecords().map((record) => record.filename);
 };
 
 const getCredentialExpiry = (credential: CredentialData): number | null => {
@@ -202,30 +208,60 @@ const formatTimeRemaining = (expiresAt: number | null): string => {
   return `${Math.ceil(remaining / 86400)}d`;
 };
 
-const getCredentialStatus = (
+const getEligibleRecords = (
   records: CredentialRecord[],
-): { records: CredentialRecord[]; indices: number[] } => {
-  const validIndices = records.reduce<number[]>((result, record, index) => {
-    if (!isCredentialExpired(record.data)) {
-      result.push(index);
+  allowedCredentialFilenames?: string[],
+): CredentialRecord[] => {
+  const allowedSet = allowedCredentialFilenames?.length
+    ? new Set(allowedCredentialFilenames)
+    : null;
+
+  return records.filter((record) => {
+    if (isCredentialExpired(record.data)) {
+      return false;
     }
 
-    return result;
-  }, []);
+    if (allowedSet && !allowedSet.has(record.filename)) {
+      return false;
+    }
 
-  return { records, indices: validIndices };
+    return true;
+  });
 };
 
-const getSafeIndex = (records: CredentialRecord[], index: number): number => {
-  if (!records.length) {
-    return -1;
+const chooseNextRecord = (
+  eligibleRecords: CredentialRecord[],
+  nextFilename: string | null,
+): { current: CredentialRecord; nextFilename: string } => {
+  const currentIndex = nextFilename
+    ? eligibleRecords.findIndex((record) => record.filename === nextFilename)
+    : -1;
+  const resolvedIndex = currentIndex >= 0 ? currentIndex : 0;
+  const current = eligibleRecords[resolvedIndex];
+  const nextIndex = (resolvedIndex + 1) % eligibleRecords.length;
+
+  return {
+    current,
+    nextFilename: eligibleRecords[nextIndex]?.filename ?? current.filename,
+  };
+};
+
+const peekNextFilename = (
+  eligibleRecords: CredentialRecord[],
+  nextFilename: string | null,
+): string | null => {
+  if (!eligibleRecords.length) {
+    return null;
   }
 
-  if (index >= 0 && index < records.length) {
-    return index;
+  if (
+    nextFilename &&
+    eligibleRecords.some((record) => record.filename === nextFilename)
+  ) {
+    return nextFilename;
   }
 
-  return 0;
+  return eligibleRecords[0]?.filename ?? null;
 };
 
 export const listCredentials = (): {
@@ -244,34 +280,34 @@ export const listCredentials = (): {
         getNestedValue(record.data, ['tenant_id', 'tenantId']) ?? enterpriseId;
 
       return {
-        index,
-        filename: record.filename,
-        user_id:
-          record.data.user_id ?? record.data.user_info?.email ?? 'unknown',
+        created_at: record.data.created_at ?? null,
+        domain:
+          getNestedValue(record.data, ['domain']) ?? 'copilot.tencent.com',
         email:
           (record.data.user_info as Record<string, unknown> | undefined)
             ?.email ??
           record.data.user_id ??
           'unknown',
+        enterprise_id: enterpriseId,
+        expires_at: expiresAt,
+        expires_in: record.data.expires_in ?? null,
+        filename: record.filename,
+        has_refresh_token: Boolean(record.data.refresh_token),
+        index,
+        is_expired: isCredentialExpired(record.data),
         name:
           (record.data.user_info as Record<string, unknown> | undefined)
             ?.name ?? null,
-        created_at: record.data.created_at ?? null,
-        expires_in: record.data.expires_in ?? null,
-        expires_at: expiresAt,
+        scope: record.data.scope ?? null,
+        session_state: record.data.session_state ?? null,
+        tenant_id: tenantId,
         time_remaining: expiresAt
           ? expiresAt - Math.floor(Date.now() / 1000)
           : null,
         time_remaining_str: formatTimeRemaining(expiresAt),
-        is_expired: isCredentialExpired(record.data),
         token_type: record.data.token_type ?? 'Bearer',
-        scope: record.data.scope ?? null,
-        domain:
-          getNestedValue(record.data, ['domain']) ?? 'copilot.tencent.com',
-        enterprise_id: enterpriseId,
-        tenant_id: tenantId,
-        has_refresh_token: Boolean(record.data.refresh_token),
-        session_state: record.data.session_state ?? null,
+        user_id:
+          record.data.user_id ?? record.data.user_info?.email ?? 'unknown',
       };
     }),
   };
@@ -279,41 +315,53 @@ export const listCredentials = (): {
 
 export const getCurrentCredentialInfo = (): Record<string, unknown> => {
   const records = readCredentialRecords();
+  const availableRecords = getEligibleRecords(records);
+  const state = getRuntimeState();
 
-  if (!records.length) {
+  if (hasAccessKeys()) {
+    return {
+      available_credential_count: availableRecords.length,
+      next_filename: peekNextFilename(
+        availableRecords,
+        state.globalNextFilename,
+      ),
+      status: 'access_keys_enabled',
+    };
+  }
+
+  if (!availableRecords.length) {
     return { status: 'no_credentials' };
   }
 
-  const state = getRuntimeState();
-  const index =
-    state.manualSelectedIndex ?? getSafeIndex(records, state.currentIndex);
-  const record = records[getSafeIndex(records, index)];
-  const enterpriseId = getNestedValue(record.data, [
+  const nextFilename = peekNextFilename(
+    availableRecords,
+    state.globalNextFilename,
+  );
+  const current =
+    availableRecords.find((record) => record.filename === nextFilename) ??
+    availableRecords[0];
+  const enterpriseId = getNestedValue(current.data, [
     'enterprise_id',
     'enterpriseId',
   ]);
   const tenantId =
-    getNestedValue(record.data, ['tenant_id', 'tenantId']) ?? enterpriseId;
+    getNestedValue(current.data, ['tenant_id', 'tenantId']) ?? enterpriseId;
 
   return {
-    status:
-      state.manualSelectedIndex !== null ? 'manual_selected' : 'auto_rotation',
-    index,
-    filename: record.filename,
-    user_id: record.data.user_id ?? 'unknown',
-    domain: getNestedValue(record.data, ['domain']) ?? 'copilot.tencent.com',
+    domain: getNestedValue(current.data, ['domain']) ?? 'copilot.tencent.com',
     enterprise_id: enterpriseId,
+    filename: current.filename,
+    next_filename: nextFilename,
+    status: 'round_robin',
     tenant_id: tenantId,
-    usage_count: state.usageCount,
-    rotation_count: getRotationCount(),
-    auto_rotation_enabled: state.autoRotationEnabled,
+    user_id: current.data.user_id ?? 'unknown',
   };
 };
 
 export const addCredential = (
   credentialData: CredentialData,
   filename?: string,
-): { success: boolean; filename: string } => {
+): { filename: string; success: boolean } => {
   ensureCredsDir();
 
   const now = Math.floor(Date.now() / 1000);
@@ -337,125 +385,108 @@ export const addCredential = (
   saveRuntimeState();
 
   return {
-    success: true,
     filename: jsonFilename,
+    success: true,
   };
 };
 
 export const deleteCredentialByIndex = (
   index: number,
-): { success: boolean; message: string } => {
+): { message: string; success: boolean } => {
   const records = readCredentialRecords();
 
   if (index < 0 || index >= records.length) {
-    return { success: false, message: 'Invalid credential index' };
+    return { message: 'Invalid credential index', success: false };
   }
 
   fs.unlinkSync(records[index].filePath);
 
   const state = getRuntimeState();
+  const deletedFilename = records[index].filename;
 
-  if (state.manualSelectedIndex === index) {
-    state.manualSelectedIndex = null;
+  if (state.globalNextFilename === deletedFilename) {
+    state.globalNextFilename = null;
   }
 
-  state.currentIndex = 0;
-  state.usageCount = 0;
+  Object.entries(state.keyNextFilenameByAccessKeyId).forEach(([key, value]) => {
+    if (value === deletedFilename) {
+      state.keyNextFilenameByAccessKeyId[key] = null;
+    }
+  });
   saveRuntimeState();
 
-  return { success: true, message: 'Credential deleted' };
+  return { message: 'Credential deleted', success: true };
 };
 
 export const selectCredential = (
   index: number,
-): { success: boolean; message: string } => {
+): { message: string; success: boolean } => {
   const records = readCredentialRecords();
 
   if (index < 0 || index >= records.length) {
-    return { success: false, message: 'Invalid credential index' };
+    return { message: 'Invalid credential index', success: false };
   }
 
   const state = getRuntimeState();
-  state.manualSelectedIndex = index;
-  state.currentIndex = index;
-  state.usageCount = 0;
-  saveRuntimeState();
-
-  return { success: true, message: 'Credential selected' };
-};
-
-export const resumeAutoRotation = (): { success: boolean; message: string } => {
-  const state = getRuntimeState();
-  state.manualSelectedIndex = null;
-  state.autoRotationEnabled = true;
-  state.usageCount = 0;
-  saveRuntimeState();
-
-  return { success: true, message: 'Automatic rotation resumed' };
-};
-
-export const toggleAutoRotation = (): {
-  success: boolean;
-  auto_rotation_enabled: boolean;
-} => {
-  const state = getRuntimeState();
-  state.autoRotationEnabled = !state.autoRotationEnabled;
+  state.globalNextFilename = records[index].filename;
   saveRuntimeState();
 
   return {
+    message: 'Next credential updated for round-robin',
     success: true,
-    auto_rotation_enabled: state.autoRotationEnabled,
   };
 };
 
-export const resolveCredentialForRequest = (): CredentialRecord | null => {
-  const records = readCredentialRecords();
+export const resumeAutoRotation = (): { message: string; success: boolean } => {
+  return {
+    message: 'Round-robin is always enabled',
+    success: true,
+  };
+};
 
-  if (!records.length) {
+export const toggleAutoRotation = (): {
+  auto_rotation_enabled: boolean;
+  success: boolean;
+} => {
+  return {
+    auto_rotation_enabled: true,
+    success: true,
+  };
+};
+
+export const resolveCredentialForRequest = ({
+  accessKeyId,
+  allowedCredentialFilenames,
+}: {
+  accessKeyId?: string;
+  allowedCredentialFilenames?: string[];
+} = {}): CredentialRecord | null => {
+  const records = readCredentialRecords();
+  const eligibleRecords = getEligibleRecords(
+    records,
+    allowedCredentialFilenames,
+  );
+
+  if (!eligibleRecords.length) {
     return null;
   }
 
   const state = getRuntimeState();
-  const { indices } = getCredentialStatus(records);
+  const stateKey = accessKeyId ? `key:${accessKeyId}` : 'global';
+  const currentNextFilename = accessKeyId
+    ? (state.keyNextFilenameByAccessKeyId[accessKeyId] ?? null)
+    : state.globalNextFilename;
+  const { current, nextFilename } = chooseNextRecord(
+    eligibleRecords,
+    currentNextFilename,
+  );
 
-  if (!indices.length) {
-    return null;
+  if (stateKey === 'global') {
+    state.globalNextFilename = nextFilename;
+  } else {
+    state.keyNextFilenameByAccessKeyId[accessKeyId!] = nextFilename;
   }
 
-  const manualIndex = state.manualSelectedIndex;
-
-  if (
-    manualIndex !== null &&
-    manualIndex >= 0 &&
-    manualIndex < records.length &&
-    !isCredentialExpired(records[manualIndex].data)
-  ) {
-    recordCredentialUsage(records[manualIndex].filename);
-    return records[manualIndex];
-  }
-
-  if (!indices.includes(state.currentIndex)) {
-    state.currentIndex = indices[0];
-    state.usageCount = 0;
-  }
-
-  const rotationCount = getRotationCount();
-
-  if (!state.autoRotationEnabled || rotationCount <= 0) {
-    const current = records[getSafeIndex(records, state.currentIndex)];
-    recordCredentialUsage(current.filename);
-    return current;
-  }
-
-  if (state.usageCount >= rotationCount) {
-    const currentPosition = indices.indexOf(state.currentIndex);
-    const nextPosition = (currentPosition + 1) % indices.length;
-    state.currentIndex = indices[nextPosition];
-    state.usageCount = 0;
-  }
-
-  const current = records[getSafeIndex(records, state.currentIndex)];
-  state.usageCount += 1;
   recordCredentialUsage(current.filename);
   saveRuntimeState();
 

--- a/tests/admin-console.test.tsx
+++ b/tests/admin-console.test.tsx
@@ -16,6 +16,19 @@ const makeJsonResponse = (payload: Record<string, unknown>, status = 200) => {
 
 describe('AdminConsole', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        addEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+      })),
+      writable: true,
+    });
+
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: {
@@ -114,5 +127,31 @@ describe('AdminConsole', () => {
         document.getElementById('authUrlSection')?.classList.contains('hidden'),
       ).toBe(false);
     });
+  });
+
+  it('supports system theme and keeps test result panel theme-safe', async () => {
+    vi.mocked(globalThis.localStorage.getItem).mockImplementation((key) => {
+      if (key === 'codebuddy2api-admin-theme') {
+        return 'system';
+      }
+
+      return null;
+    });
+
+    render(React.createElement(AdminConsole));
+
+    const themeSelect = await screen.findByLabelText('Theme mode');
+
+    expect((themeSelect as HTMLSelectElement).value).toBe('system');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    fireEvent.click(screen.getByText('API 测试'));
+
+    const testResult = await screen.findByText('点击"发送测试"查看API响应...');
+    const resultPanel = testResult.closest('#testResult');
+
+    expect(resultPanel).not.toBeNull();
+    expect(resultPanel?.className).toContain('text-text-light');
+    expect(resultPanel?.className).not.toContain('bg-bg-dark text-text-dark');
   });
 });

--- a/tests/anthropic.test.ts
+++ b/tests/anthropic.test.ts
@@ -48,10 +48,8 @@ describe('anthropic messages api', () => {
     process.env.CODEBUDDY_CONFIG_PATH =
       '.tmp-test-config-anthropic/config.json';
     process.env.CODEBUDDY_CREDS_DIR = '.tmp-test-creds-anthropic';
-    process.env.CODEBUDDY_PASSWORD = '';
     process.env.CODEBUDDY_AUTH_MODE = 'api_key';
     process.env.CODEBUDDY_API_KEY = 'cb-key';
-    process.env.CODEBUDDY_ROTATION_COUNT = '1';
   });
 
   afterEach(() => {

--- a/tests/server-runtime.test.ts
+++ b/tests/server-runtime.test.ts
@@ -4,6 +4,9 @@ import path from 'node:path';
 import { NextRequest } from 'next/server';
 
 import * as AdminChatRoute from '@/app/admin-api/chat/completions/route';
+import * as AdminAccessKeysByIdRoute from '@/app/admin-api/access-keys/[id]/route';
+import * as AdminAccessKeySecretRoute from '@/app/admin-api/access-keys/[id]/secret/route';
+import * as AdminAccessKeysRoute from '@/app/admin-api/access-keys/route';
 import * as AdminCredentialsAutoRoute from '@/app/admin-api/credentials/auto/route';
 import * as AdminCredentialsCurrentRoute from '@/app/admin-api/credentials/current/route';
 import * as AdminCredentialsDeleteRoute from '@/app/admin-api/credentials/delete/route';
@@ -84,7 +87,6 @@ describe('server runtime', () => {
     vi.restoreAllMocks();
     process.env.CODEBUDDY_CONFIG_PATH = '.tmp-test-config/config.json';
     process.env.CODEBUDDY_CREDS_DIR = '.tmp-test-creds';
-    process.env.CODEBUDDY_PASSWORD = '';
     process.env.CODEBUDDY_AUTH_MODE = 'auto';
     process.env.CODEBUDDY_API_KEY = '';
   });
@@ -108,18 +110,17 @@ describe('server runtime', () => {
 
   it('manages settings and credentials through admin routes', async () => {
     const settingsBefore = await (await AdminSettingsRoute.GET()).json();
-    expect(settingsBefore.settings.CODEBUDDY_ROTATION_COUNT).toBe(1);
+    expect(settingsBefore.settings.CODEBUDDY_AUTH_MODE).toBe('auto');
 
     const saveResponse = await AdminSettingsRoute.POST(
       makeJsonRequest('http://localhost/admin-api/settings', {
         settings: {
-          CODEBUDDY_ROTATION_COUNT: 5,
           CODEBUDDY_AUTH_MODE: 'token',
         },
       }),
     );
     const savedPayload = await saveResponse.json();
-    expect(savedPayload.settings.CODEBUDDY_ROTATION_COUNT).toBe(5);
+    expect(savedPayload.settings.CODEBUDDY_AUTH_MODE).toBe('token');
     expect(fs.existsSync(path.join(tempConfigDir, 'config.json'))).toBe(true);
 
     const addResponse = await AdminCredentialsRoute.POST(
@@ -142,14 +143,47 @@ describe('server runtime', () => {
     ).json();
     expect(currentPayload.filename).toContain('.json');
 
-    const selectPayload = await (
-      await AdminCredentialsSelectRoute.POST(
-        makeJsonRequest('http://localhost/admin-api/credentials/select', {
-          index: 0,
+    const createdAccessKeyPayload = await (
+      await AdminAccessKeysRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/access-keys', {
+          credential_filenames: [listPayload.credentials[0].filename],
+          name: 'Alice Key',
         }),
       )
     ).json();
-    expect(selectPayload.success).toBe(true);
+    expect(createdAccessKeyPayload.secret.startsWith('cb2_')).toBe(true);
+    expect(createdAccessKeyPayload.access_key.name).toBe('Alice Key');
+
+    const listedAccessKeys = await (await AdminAccessKeysRoute.GET()).json();
+    expect(listedAccessKeys.access_keys).toHaveLength(1);
+    expect(listedAccessKeys.access_keys[0].maskedSecret).toContain('...');
+
+    const revealedSecretPayload = await (
+      await AdminAccessKeySecretRoute.GET(new Request('http://localhost'), {
+        params: Promise.resolve({
+          id: createdAccessKeyPayload.access_key.id,
+        }),
+      })
+    ).json();
+    expect(revealedSecretPayload.secret).toBe(createdAccessKeyPayload.secret);
+
+    const updatedAccessKeyPayload = await (
+      await AdminAccessKeysByIdRoute.PATCH(
+        makeJsonRequest(
+          `http://localhost/admin-api/access-keys/${createdAccessKeyPayload.access_key.id}`,
+          {
+            credential_filenames: [listPayload.credentials[0].filename],
+            name: 'Alice Key Updated',
+          },
+        ),
+        {
+          params: Promise.resolve({
+            id: createdAccessKeyPayload.access_key.id,
+          }),
+        },
+      )
+    ).json();
+    expect(updatedAccessKeyPayload.access_key.name).toBe('Alice Key Updated');
 
     const invalidSelectResponse = await AdminCredentialsSelectRoute.POST(
       makeJsonRequest('http://localhost/admin-api/credentials/select', {
@@ -161,10 +195,19 @@ describe('server runtime', () => {
     const togglePayload = await (
       await AdminCredentialsToggleRoute.POST()
     ).json();
-    expect(togglePayload.auto_rotation_enabled).toBe(false);
+    expect(togglePayload.auto_rotation_enabled).toBe(true);
 
     const autoPayload = await (await AdminCredentialsAutoRoute.POST()).json();
     expect(autoPayload.success).toBe(true);
+
+    const deletedAccessKeyPayload = await (
+      await AdminAccessKeysByIdRoute.DELETE(new Request('http://localhost'), {
+        params: Promise.resolve({
+          id: createdAccessKeyPayload.access_key.id,
+        }),
+      })
+    ).json();
+    expect(deletedAccessKeyPayload.success).toBe(true);
 
     const deletePayload = await (
       await AdminCredentialsDeleteRoute.POST(
@@ -177,8 +220,22 @@ describe('server runtime', () => {
   });
 
   it('enforces auth on protected v1 routes and mirrors successful actions', async () => {
-    process.env.CODEBUDDY_PASSWORD = 'secret';
+    await AdminCredentialsRoute.POST(
+      makeJsonRequest('http://localhost/admin-api/credentials', {
+        bearer_token: 'token-b',
+        user_id: 'bob@example.com',
+      }),
+    );
 
+    const credentialList = await (await AdminCredentialsRoute.GET()).json();
+    const createdAccessKeyPayload = await (
+      await AdminAccessKeysRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/access-keys', {
+          credential_filenames: [credentialList.credentials[0].filename],
+          name: 'Protected Key',
+        }),
+      )
+    ).json();
     const unauthorizedModels = await V1ModelsRoute.GET(
       makeNextRequest('http://localhost/v1/models'),
     );
@@ -189,15 +246,8 @@ describe('server runtime', () => {
     );
     expect(unauthorized.status).toBe(401);
 
-    await AdminCredentialsRoute.POST(
-      makeJsonRequest('http://localhost/admin-api/credentials', {
-        bearer_token: 'token-b',
-        user_id: 'bob@example.com',
-      }),
-    );
-
     const authHeaders = {
-      authorization: 'Bearer secret',
+      authorization: `Bearer ${createdAccessKeyPayload.secret}`,
     };
     const listPayload = await (
       await V1CredentialsRoute.GET(
@@ -224,7 +274,8 @@ describe('server runtime', () => {
         }),
       )
     ).json();
-    expect(currentPayload.user_id).toBe('bob@example.com');
+    expect(currentPayload.status).toBe('access_keys_enabled');
+    expect(currentPayload.available_credential_count).toBe(1);
 
     const selectPayload = await (
       await V1CredentialsSelectRoute.POST(
@@ -300,7 +351,6 @@ describe('server runtime', () => {
   });
 
   it('proxies chat completions for admin and v1 endpoints', async () => {
-    process.env.CODEBUDDY_PASSWORD = 'secret';
     process.env.CODEBUDDY_AUTH_MODE = 'api_key';
     process.env.CODEBUDDY_API_KEY = 'cb-key';
 
@@ -335,7 +385,7 @@ describe('server runtime', () => {
       makeNextRequest('http://localhost/v1/chat/completions', {
         method: 'POST',
         headers: {
-          authorization: 'Bearer secret',
+          authorization: 'Bearer ignored-without-access-key',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -354,7 +404,6 @@ describe('server runtime', () => {
   });
 
   it('supports responses api for non-stream, stream, tool flattening, and previous response state', async () => {
-    process.env.CODEBUDDY_PASSWORD = 'secret';
     process.env.CODEBUDDY_AUTH_MODE = 'api_key';
     process.env.CODEBUDDY_API_KEY = 'cb-key';
 
@@ -581,8 +630,6 @@ describe('server runtime', () => {
   });
 
   it('supports codebuddy auth start, poll, callback, and protected api settings', async () => {
-    process.env.CODEBUDDY_PASSWORD = 'secret';
-
     const jwtPayload = Buffer.from(
       JSON.stringify({
         email: 'coder@example.com',
@@ -662,6 +709,14 @@ describe('server runtime', () => {
     ).json();
     expect(callbackPayload.code).toBe('ok');
 
+    const accessKeyPayload = await (
+      await AdminAccessKeysRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/access-keys', {
+          credential_filenames: [credentialListPayload.credentials[0].filename],
+          name: 'Settings Key',
+        }),
+      )
+    ).json();
     const forbiddenSettings = await ApiSettingsRoute.GET(
       makeNextRequest('http://localhost/api/settings'),
     );
@@ -670,7 +725,7 @@ describe('server runtime', () => {
     const protectedSettings = await ApiSettingsRoute.GET(
       makeNextRequest('http://localhost/api/settings', {
         headers: {
-          authorization: 'Bearer secret',
+          authorization: `Bearer ${accessKeyPayload.secret}`,
         },
       }),
     );

--- a/tests/server-runtime.test.ts
+++ b/tests/server-runtime.test.ts
@@ -93,6 +93,7 @@ describe('server runtime', () => {
 
   afterEach(() => {
     cleanupTempState();
+    delete process.env.CODEBUDDY_PASSWORD;
   });
 
   it('serves health and model metadata', async () => {
@@ -220,6 +221,8 @@ describe('server runtime', () => {
   });
 
   it('enforces auth on protected v1 routes and mirrors successful actions', async () => {
+    process.env.CODEBUDDY_PASSWORD = 'legacy-secret';
+
     await AdminCredentialsRoute.POST(
       makeJsonRequest('http://localhost/admin-api/credentials', {
         bearer_token: 'token-b',
@@ -246,17 +249,26 @@ describe('server runtime', () => {
     );
     expect(unauthorized.status).toBe(401);
 
-    const authHeaders = {
-      authorization: `Bearer ${createdAccessKeyPayload.secret}`,
-    };
-    const listPayload = await (
+    const legacyListPayload = await (
       await V1CredentialsRoute.GET(
         makeNextRequest('http://localhost/v1/credentials', {
-          headers: authHeaders,
+          headers: {
+            authorization: 'Bearer legacy-secret',
+          },
         }),
       )
     ).json();
-    expect(listPayload.credentials).toHaveLength(1);
+    expect(legacyListPayload.credentials).toHaveLength(1);
+
+    const authHeaders = {
+      authorization: `Bearer ${createdAccessKeyPayload.secret}`,
+    };
+    const listResponse = await V1CredentialsRoute.GET(
+      makeNextRequest('http://localhost/v1/credentials', {
+        headers: authHeaders,
+      }),
+    );
+    expect(listResponse.status).toBe(403);
 
     const authorizedModels = await (
       await V1ModelsRoute.GET(
@@ -267,29 +279,24 @@ describe('server runtime', () => {
     ).json();
     expect(authorizedModels.object).toBe('list');
 
-    const currentPayload = await (
-      await V1CredentialsCurrentRoute.GET(
-        makeNextRequest('http://localhost/v1/credentials/current', {
-          headers: authHeaders,
-        }),
-      )
-    ).json();
-    expect(currentPayload.status).toBe('access_keys_enabled');
-    expect(currentPayload.available_credential_count).toBe(1);
+    const currentResponse = await V1CredentialsCurrentRoute.GET(
+      makeNextRequest('http://localhost/v1/credentials/current', {
+        headers: authHeaders,
+      }),
+    );
+    expect(currentResponse.status).toBe(403);
 
-    const selectPayload = await (
-      await V1CredentialsSelectRoute.POST(
-        makeNextRequest('http://localhost/v1/credentials/select', {
-          method: 'POST',
-          headers: {
-            ...authHeaders,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ index: 0 }),
-        }),
-      )
-    ).json();
-    expect(selectPayload.success).toBe(true);
+    const selectResponse = await V1CredentialsSelectRoute.POST(
+      makeNextRequest('http://localhost/v1/credentials/select', {
+        method: 'POST',
+        headers: {
+          ...authHeaders,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ index: 0 }),
+      }),
+    );
+    expect(selectResponse.status).toBe(403);
 
     const invalidSelectResponse = await V1CredentialsSelectRoute.POST(
       makeNextRequest('http://localhost/v1/credentials/select', {
@@ -301,27 +308,23 @@ describe('server runtime', () => {
         body: JSON.stringify({ index: null }),
       }),
     );
-    expect(invalidSelectResponse.status).toBe(400);
+    expect(invalidSelectResponse.status).toBe(403);
 
-    const togglePayload = await (
-      await V1CredentialsToggleRoute.POST(
-        makeNextRequest('http://localhost/v1/credentials/toggle-rotation', {
-          method: 'POST',
-          headers: authHeaders,
-        }),
-      )
-    ).json();
-    expect(togglePayload.success).toBe(true);
+    const toggleResponse = await V1CredentialsToggleRoute.POST(
+      makeNextRequest('http://localhost/v1/credentials/toggle-rotation', {
+        method: 'POST',
+        headers: authHeaders,
+      }),
+    );
+    expect(toggleResponse.status).toBe(403);
 
-    const autoPayload = await (
-      await V1CredentialsAutoRoute.POST(
-        makeNextRequest('http://localhost/v1/credentials/auto', {
-          method: 'POST',
-          headers: authHeaders,
-        }),
-      )
-    ).json();
-    expect(autoPayload.success).toBe(true);
+    const autoResponse = await V1CredentialsAutoRoute.POST(
+      makeNextRequest('http://localhost/v1/credentials/auto', {
+        method: 'POST',
+        headers: authHeaders,
+      }),
+    );
+    expect(autoResponse.status).toBe(403);
 
     const invalidDeleteResponse = await V1CredentialsDeleteRoute.POST(
       makeNextRequest('http://localhost/v1/credentials/delete', {
@@ -333,21 +336,19 @@ describe('server runtime', () => {
         body: JSON.stringify({ index: null }),
       }),
     );
-    expect(invalidDeleteResponse.status).toBe(400);
+    expect(invalidDeleteResponse.status).toBe(403);
 
-    const deletePayload = await (
-      await V1CredentialsDeleteRoute.POST(
-        makeNextRequest('http://localhost/v1/credentials/delete', {
-          method: 'POST',
-          headers: {
-            ...authHeaders,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ index: 0 }),
-        }),
-      )
-    ).json();
-    expect(deletePayload.success).toBe(true);
+    const deleteResponse = await V1CredentialsDeleteRoute.POST(
+      makeNextRequest('http://localhost/v1/credentials/delete', {
+        method: 'POST',
+        headers: {
+          ...authHeaders,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ index: 0 }),
+      }),
+    );
+    expect(deleteResponse.status).toBe(403);
   });
 
   it('proxies chat completions for admin and v1 endpoints', async () => {
@@ -720,7 +721,13 @@ describe('server runtime', () => {
     const forbiddenSettings = await ApiSettingsRoute.GET(
       makeNextRequest('http://localhost/api/settings'),
     );
-    expect(forbiddenSettings.status).toBe(401);
+    expect(forbiddenSettings.status).toBe(200);
+
+    process.env.CODEBUDDY_PASSWORD = 'legacy-secret';
+    const missingLegacySettings = await ApiSettingsRoute.GET(
+      makeNextRequest('http://localhost/api/settings'),
+    );
+    expect(missingLegacySettings.status).toBe(401);
 
     const protectedSettings = await ApiSettingsRoute.GET(
       makeNextRequest('http://localhost/api/settings', {
@@ -729,7 +736,16 @@ describe('server runtime', () => {
         },
       }),
     );
-    expect(protectedSettings.status).toBe(200);
+    expect(protectedSettings.status).toBe(403);
+
+    const adminSettings = await ApiSettingsRoute.GET(
+      makeNextRequest('http://localhost/api/settings', {
+        headers: {
+          authorization: 'Bearer legacy-secret',
+        },
+      }),
+    );
+    expect(adminSettings.status).toBe(200);
 
     const statsPayload = await (await AdminStatsRoute.GET()).json();
     expect(statsPayload.credential_usage).toBeTruthy();

--- a/tests/server-units.test.ts
+++ b/tests/server-units.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { NextRequest } from 'next/server';
 
+import { createAccessKey } from '@/lib/server/access-keys';
 import {
   getAnthropicAuthErrorResponse,
   getAuthErrorResponse,
@@ -74,10 +75,8 @@ describe('server units', () => {
     vi.restoreAllMocks();
     process.env.CODEBUDDY_CONFIG_PATH = '.tmp-test-config/config.json';
     process.env.CODEBUDDY_CREDS_DIR = '.tmp-test-creds';
-    process.env.CODEBUDDY_PASSWORD = '';
     process.env.CODEBUDDY_AUTH_MODE = 'auto';
     process.env.CODEBUDDY_API_KEY = '';
-    process.env.CODEBUDDY_ROTATION_COUNT = '1';
   });
 
   afterEach(() => {
@@ -89,7 +88,14 @@ describe('server units', () => {
       getAuthErrorResponse(makeNextRequest('http://localhost/test')),
     ).toBeNull();
 
-    process.env.CODEBUDDY_PASSWORD = 'secret';
+    const credential = addCredential({
+      bearer_token: 'token-auth',
+      user_id: 'guard@example.com',
+    });
+    const { secret } = createAccessKey({
+      credentialFilenames: [credential.filename],
+      name: 'Guard Key',
+    });
 
     expect(
       getAuthErrorResponse(makeNextRequest('http://localhost/test'))?.status,
@@ -104,7 +110,7 @@ describe('server units', () => {
     expect(
       getAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
-          headers: { authorization: 'Bearer secret' },
+          headers: { authorization: `Bearer ${secret}` },
         }),
       ),
     ).toBeNull();
@@ -118,7 +124,14 @@ describe('server units', () => {
       ),
     ).toBeNull();
 
-    process.env.CODEBUDDY_PASSWORD = 'anthropic-secret';
+    const credential = addCredential({
+      bearer_token: 'token-anthropic',
+      user_id: 'anthropic@example.com',
+    });
+    const { secret } = createAccessKey({
+      credentialFilenames: [credential.filename],
+      name: 'Anthropic Key',
+    });
 
     // Missing key entirely.
     const noKey = getAnthropicAuthErrorResponse(
@@ -140,7 +153,7 @@ describe('server units', () => {
     expect(
       getAnthropicAuthErrorResponse(
         makeNextRequest('http://localhost/v1/messages', {
-          headers: { 'x-api-key': 'anthropic-secret' },
+          headers: { 'x-api-key': secret },
         }),
       ),
     ).toBeNull();
@@ -149,13 +162,13 @@ describe('server units', () => {
     expect(
       getAnthropicAuthErrorResponse(
         makeNextRequest('http://localhost/v1/messages', {
-          headers: { authorization: 'Bearer anthropic-secret' },
+          headers: { authorization: `Bearer ${secret}` },
         }),
       ),
     ).toBeNull();
   });
 
-  it('covers credential rotation, invalid operations, and usage stats', () => {
+  it('covers credential round-robin, invalid operations, and usage stats', () => {
     expect(getCurrentCredentialInfo().status).toBe('no_credentials');
     expect(selectCredential(0).success).toBe(false);
     expect(deleteCredentialByIndex(0).success).toBe(false);
@@ -194,8 +207,25 @@ describe('server units', () => {
     expect(resolveCredentialForRequest()?.data.user_id).toBe('one@example.com');
 
     const toggle = toggleAutoRotation();
-    expect(toggle.auto_rotation_enabled).toBe(false);
+    expect(toggle.auto_rotation_enabled).toBe(true);
     expect(resumeAutoRotation().success).toBe(true);
+
+    const keyedCredential = addCredential({
+      bearer_token: 'token-3',
+      created_at: Math.floor(Date.now() / 1000),
+      expires_in: 3600,
+      user_id: 'keyed@example.com',
+    });
+    const keyedAccess = createAccessKey({
+      credentialFilenames: [keyedCredential.filename],
+      name: 'Subset Key',
+    });
+    expect(
+      resolveCredentialForRequest({
+        accessKeyId: keyedAccess.access_key.id,
+        allowedCredentialFilenames: keyedAccess.access_key.credentialFilenames,
+      })?.filename,
+    ).toBe(keyedCredential.filename);
 
     recordModelUsage('glm-5.1');
     recordCredentialUsage('cred-a');
@@ -1223,7 +1253,7 @@ describe('server units', () => {
 
     // The credential should have been saved with enterprise/tenant info.
     const credInfo = getCurrentCredentialInfo();
-    expect(credInfo.status).toBe('auto_rotation');
+    expect(credInfo.status).toBe('round_robin');
     expect(credInfo.tenant_id).toBe('tenant-456');
   });
 
@@ -1662,11 +1692,10 @@ describe('server units', () => {
   });
 
   it('coerces nullable string settings to strings', () => {
-    updateSettings({ CODEBUDDY_PASSWORD: 12345, CODEBUDDY_API_KEY: true });
+    updateSettings({ CODEBUDDY_API_KEY: true });
 
     const config = getActiveConfig();
 
-    expect(config.CODEBUDDY_PASSWORD).toBe('12345');
     expect(config.CODEBUDDY_API_KEY).toBe('true');
   });
 });

--- a/tests/server-units.test.ts
+++ b/tests/server-units.test.ts
@@ -3,7 +3,17 @@ import path from 'node:path';
 
 import { NextRequest } from 'next/server';
 
-import { createAccessKey } from '@/lib/server/access-keys';
+import {
+  createAccessKey,
+  deleteAccessKey,
+  findAccessKeyById,
+  findAccessKeyBySecret,
+  getAccessKeySecret,
+  hasAccessKeys,
+  listAccessKeys,
+  listStoredAccessKeys,
+  updateAccessKey,
+} from '@/lib/server/access-keys';
 import {
   getAnthropicAuthErrorResponse,
   getAuthErrorResponse,
@@ -39,12 +49,12 @@ import {
   resetUsageStats,
 } from '@/lib/server/stats';
 
-const tempConfigDir = path.join(process.cwd(), '.tmp-test-config');
-const tempCredsDir = path.join(process.cwd(), '.tmp-test-creds');
+const tempConfigDir = path.join(process.cwd(), '.tmp-test-config-units');
+const tempCredsDir = path.join(process.cwd(), '.tmp-test-creds-units');
 
 const cleanupTempState = (): void => {
-  fs.rmSync(tempConfigDir, { force: true, recursive: true });
-  fs.rmSync(tempCredsDir, { force: true, recursive: true });
+  fs.rmSync(tempConfigDir, { force: true, recursive: true, maxRetries: 5 });
+  fs.rmSync(tempCredsDir, { force: true, recursive: true, maxRetries: 5 });
 };
 
 const makeNextRequest = (
@@ -73,8 +83,8 @@ describe('server units', () => {
     resetResponseSessions();
     resetUsageStats();
     vi.restoreAllMocks();
-    process.env.CODEBUDDY_CONFIG_PATH = '.tmp-test-config/config.json';
-    process.env.CODEBUDDY_CREDS_DIR = '.tmp-test-creds';
+    process.env.CODEBUDDY_CONFIG_PATH = '.tmp-test-config-units/config.json';
+    process.env.CODEBUDDY_CREDS_DIR = '.tmp-test-creds-units';
     process.env.CODEBUDDY_AUTH_MODE = 'auto';
     process.env.CODEBUDDY_API_KEY = '';
   });
@@ -103,6 +113,13 @@ describe('server units', () => {
     expect(
       getAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Basic nope' },
+        }),
+      )?.status,
+    ).toBe(401);
+    expect(
+      getAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
           headers: { authorization: 'Bearer nope' },
         }),
       )?.status,
@@ -110,7 +127,14 @@ describe('server units', () => {
     expect(
       getAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
-          headers: { authorization: `Bearer ${secret}` },
+          headers: { authorization: `Bearer ${secret} trailing` },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      getAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
+          headers: { 'x-api-key': secret },
         }),
       ),
     ).toBeNull();
@@ -141,13 +165,13 @@ describe('server units', () => {
     expect((await noKey!.json()).type).toBe('error');
 
     // Wrong key via x-api-key.
-    expect(
-      getAnthropicAuthErrorResponse(
-        makeNextRequest('http://localhost/v1/messages', {
-          headers: { 'x-api-key': 'wrong' },
-        }),
-      )?.status,
-    ).toBe(403);
+    const wrongKey = getAnthropicAuthErrorResponse(
+      makeNextRequest('http://localhost/v1/messages', {
+        headers: { 'x-api-key': 'wrong' },
+      }),
+    );
+    expect(wrongKey?.status).toBe(403);
+    expect(wrongKey).not.toBeNull();
 
     // Correct key via x-api-key.
     expect(
@@ -195,8 +219,14 @@ describe('server units', () => {
     });
 
     const listed = listCredentials();
-    expect(listed.credentials[0].is_expired).toBe(true);
-    expect(listed.credentials[1].tenant_id).toBe('tenant-a');
+    const expiredCredential = listed.credentials.find((item) => {
+      return item.user_id === 'expired@example.com' || item.is_expired === true;
+    });
+    const tenantCredential = listed.credentials.find(
+      (item) => item.user_id === 'one@example.com',
+    );
+    expect(expiredCredential?.is_expired).toBe(true);
+    expect(tenantCredential?.tenant_id).toBe('tenant-a');
 
     const first = resolveCredentialForRequest();
     const second = resolveCredentialForRequest();
@@ -231,6 +261,118 @@ describe('server units', () => {
     recordCredentialUsage('cred-a');
     expect(getUsageStats().model_usage['glm-5.1']).toBe(1);
     expect(getUsageStats().credential_usage['cred-a']).toBe(1);
+  });
+
+  it('covers access key store edge cases and mutation failures', () => {
+    expect(hasAccessKeys()).toBe(false);
+    expect(findAccessKeyBySecret('   ')).toBeNull();
+    expect(getAccessKeySecret('missing')).toBeNull();
+    expect(deleteAccessKey('missing')).toBe(false);
+    expect(listAccessKeys().access_keys).toEqual([]);
+    expect(listStoredAccessKeys()).toEqual([]);
+
+    fs.mkdirSync(tempConfigDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tempConfigDir, 'access-keys.json'),
+      JSON.stringify({
+        accessKeys: [
+          {
+            id: 'valid-id',
+            name: 'Valid Key',
+            secret: 'shortsecret',
+            createdAt: '2026-07-10T00:00:00.000Z',
+            updatedAt: '2026-07-10T00:00:00.000Z',
+            credentialFilenames: ['cred-b.json', 'cred-a.json'],
+          },
+          {
+            id: 'invalid-id',
+            name: 'Broken Key',
+            credentialFilenames: 'bad-shape',
+          },
+        ],
+      }),
+    );
+
+    expect(hasAccessKeys()).toBe(true);
+    expect(findAccessKeyById('valid-id')?.name).toBe('Valid Key');
+    expect(findAccessKeyBySecret('shortsecret')?.id).toBe('valid-id');
+    expect(getAccessKeySecret('valid-id')?.secret).toBe('shortsecret');
+    expect(listStoredAccessKeys()).toHaveLength(1);
+    expect(listAccessKeys().access_keys[0]?.maskedSecret).toBe('shor****');
+
+    fs.writeFileSync(path.join(tempConfigDir, 'access-keys.json'), '{');
+    expect(listStoredAccessKeys()).toEqual([]);
+    expect(hasAccessKeys()).toBe(false);
+  });
+
+  it('covers access key validation, normalization, and deletion', () => {
+    const firstCredential = addCredential({
+      bearer_token: 'token-first',
+      user_id: 'first@example.com',
+    });
+    const secondCredential = addCredential({
+      bearer_token: 'token-second',
+      user_id: 'second@example.com',
+    });
+
+    expect(() =>
+      createAccessKey({
+        credentialFilenames: [firstCredential.filename],
+        name: '   ',
+      }),
+    ).toThrow('Access key name is required');
+    expect(() =>
+      createAccessKey({
+        credentialFilenames: ['   '],
+        name: 'Missing Credentials',
+      }),
+    ).toThrow('At least one credential must be selected');
+
+    const created = createAccessKey({
+      credentialFilenames: [
+        ` ${secondCredential.filename} `,
+        firstCredential.filename,
+        secondCredential.filename,
+      ],
+      name: '  Mixed Key  ',
+    });
+    expect(created.access_key.name).toBe('Mixed Key');
+    expect(created.access_key.credentialFilenames).toEqual([
+      firstCredential.filename,
+      secondCredential.filename,
+    ]);
+    expect(created.secret.startsWith('cb2_')).toBe(true);
+    expect(created.access_key.maskedSecret).toContain('...');
+
+    expect(() =>
+      updateAccessKey(created.access_key.id, {
+        credentialFilenames: [firstCredential.filename],
+        name: '   ',
+      }),
+    ).toThrow('Access key name is required');
+    expect(() =>
+      updateAccessKey(created.access_key.id, {
+        credentialFilenames: [],
+        name: 'Still Bad',
+      }),
+    ).toThrow('At least one credential must be selected');
+    expect(() =>
+      updateAccessKey('missing-id', {
+        credentialFilenames: [firstCredential.filename],
+        name: 'Unknown Key',
+      }),
+    ).toThrow('Access key not found');
+
+    const updated = updateAccessKey(created.access_key.id, {
+      credentialFilenames: [secondCredential.filename],
+      name: 'Updated Key',
+    });
+    expect(updated.name).toBe('Updated Key');
+    expect(updated.credentialFilenames).toEqual([secondCredential.filename]);
+
+    expect(deleteAccessKey(created.access_key.id)).toBe(true);
+    expect(findAccessKeyById(created.access_key.id)).toBeNull();
+    expect(getAccessKeySecret(created.access_key.id)).toBeNull();
   });
 
   it('covers chat proxy error, token auth, and streaming branches', async () => {

--- a/tests/server-units.test.ts
+++ b/tests/server-units.test.ts
@@ -18,6 +18,7 @@ import {
   getAdminAuthErrorResponse,
   getAnthropicAuthErrorResponse,
   getClientAuthErrorResponse,
+  resolveRequestAccessKey,
 } from '@/lib/server/auth';
 import {
   getAuthCallbackResponse,
@@ -104,7 +105,7 @@ describe('server units', () => {
       bearer_token: 'token-auth',
       user_id: 'guard@example.com',
     });
-    const { secret } = createAccessKey({
+    const created = createAccessKey({
       credentialFilenames: [credential.filename],
       name: 'Guard Key',
     });
@@ -130,14 +131,14 @@ describe('server units', () => {
     expect(
       getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
-          headers: { authorization: `Bearer ${secret} trailing` },
+          headers: { authorization: `Bearer ${created.secret} trailing` },
         }),
       ),
     ).toBeNull();
     expect(
       getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
-          headers: { 'x-api-key': secret },
+          headers: { 'x-api-key': created.secret },
         }),
       ),
     ).toBeNull();
@@ -176,7 +177,7 @@ describe('server units', () => {
       bearer_token: 'token-auth',
       user_id: 'guard@example.com',
     });
-    const { secret } = createAccessKey({
+    const created = createAccessKey({
       credentialFilenames: [credential.filename],
       name: 'Guard Key',
     });
@@ -184,17 +185,78 @@ describe('server units', () => {
     expect(
       getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
-          headers: { authorization: `Bearer ${secret}` },
+          headers: { authorization: `Bearer ${created.secret}` },
         }),
       ),
     ).toBeNull();
     expect(
       getAdminAuthErrorResponse(
         makeNextRequest('http://localhost/admin', {
-          headers: { authorization: `Bearer ${secret}` },
+          headers: { authorization: `Bearer ${created.secret}` },
         }),
       )?.status,
     ).toBe(403);
+    expect(
+      resolveRequestAccessKey(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: `Bearer ${created.secret}` },
+        }),
+      )?.id,
+    ).toBe(created.access_key.id);
+    expect(
+      resolveRequestAccessKey(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Bearer legacy-secret' },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('covers auth behavior when access key storage is unreadable', async () => {
+    process.env.CODEBUDDY_PASSWORD = 'legacy-secret';
+    fs.mkdirSync(tempConfigDir, { recursive: true });
+    fs.writeFileSync(path.join(tempConfigDir, 'access-keys.json'), '{');
+
+    expect(
+      resolveRequestAccessKey(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Bearer any-token' },
+        }),
+      ),
+    ).toBeNull();
+
+    const clientError = getClientAuthErrorResponse(
+      makeNextRequest('http://localhost/test', {
+        headers: { authorization: 'Bearer any-token' },
+      }),
+    );
+    expect(clientError?.status).toBe(503);
+    expect(await clientError?.json()).toEqual({
+      error: {
+        message:
+          'Access key storage is unreadable. Fix access-keys.json first.',
+      },
+    });
+
+    const adminError = getAdminAuthErrorResponse(
+      makeNextRequest('http://localhost/admin', {
+        headers: { authorization: 'Bearer legacy-secret' },
+      }),
+    );
+    expect(adminError?.status).toBe(503);
+
+    const anthropicError = getAnthropicAuthErrorResponse(
+      makeNextRequest('http://localhost/v1/messages', {
+        headers: { authorization: 'Bearer legacy-secret' },
+      }),
+    );
+    expect(anthropicError?.status).toBe(503);
+    expect(await anthropicError?.json()).toMatchObject({
+      type: 'error',
+      error: {
+        type: 'authentication_error',
+      },
+    });
   });
 
   it('covers anthropic auth with x-api-key and bearer', async () => {
@@ -244,6 +306,42 @@ describe('server units', () => {
       getAnthropicAuthErrorResponse(
         makeNextRequest('http://localhost/v1/messages', {
           headers: { authorization: `Bearer ${secret}` },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('covers anthropic legacy password branches', async () => {
+    process.env.CODEBUDDY_PASSWORD = 'legacy-secret';
+
+    const missing = getAnthropicAuthErrorResponse(
+      makeNextRequest('http://localhost/v1/messages'),
+    );
+    expect(missing?.status).toBe(401);
+    expect(await missing?.json()).toMatchObject({
+      type: 'error',
+      error: {
+        message: 'Authorization header is required',
+      },
+    });
+
+    const wrong = getAnthropicAuthErrorResponse(
+      makeNextRequest('http://localhost/v1/messages', {
+        headers: { authorization: 'Bearer wrong-secret' },
+      }),
+    );
+    expect(wrong?.status).toBe(403);
+    expect(await wrong?.json()).toMatchObject({
+      type: 'error',
+      error: {
+        message: 'Invalid API key',
+      },
+    });
+
+    expect(
+      getAnthropicAuthErrorResponse(
+        makeNextRequest('http://localhost/v1/messages', {
+          headers: { authorization: 'Bearer legacy-secret' },
         }),
       ),
     ).toBeNull();

--- a/tests/server-units.test.ts
+++ b/tests/server-units.test.ts
@@ -15,8 +15,9 @@ import {
   updateAccessKey,
 } from '@/lib/server/access-keys';
 import {
+  getAdminAuthErrorResponse,
   getAnthropicAuthErrorResponse,
-  getAuthErrorResponse,
+  getClientAuthErrorResponse,
 } from '@/lib/server/auth';
 import {
   getAuthCallbackResponse,
@@ -91,11 +92,12 @@ describe('server units', () => {
 
   afterEach(() => {
     cleanupTempState();
+    delete process.env.CODEBUDDY_PASSWORD;
   });
 
   it('covers auth guard branches', () => {
     expect(
-      getAuthErrorResponse(makeNextRequest('http://localhost/test')),
+      getClientAuthErrorResponse(makeNextRequest('http://localhost/test')),
     ).toBeNull();
 
     const credential = addCredential({
@@ -108,36 +110,91 @@ describe('server units', () => {
     });
 
     expect(
-      getAuthErrorResponse(makeNextRequest('http://localhost/test'))?.status,
+      getClientAuthErrorResponse(makeNextRequest('http://localhost/test'))
+        ?.status,
     ).toBe(401);
     expect(
-      getAuthErrorResponse(
+      getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
           headers: { authorization: 'Basic nope' },
         }),
       )?.status,
     ).toBe(401);
     expect(
-      getAuthErrorResponse(
+      getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
           headers: { authorization: 'Bearer nope' },
         }),
       )?.status,
     ).toBe(403);
     expect(
-      getAuthErrorResponse(
+      getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
           headers: { authorization: `Bearer ${secret} trailing` },
         }),
       ),
     ).toBeNull();
     expect(
-      getAuthErrorResponse(
+      getClientAuthErrorResponse(
         makeNextRequest('http://localhost/test', {
           headers: { 'x-api-key': secret },
         }),
       ),
     ).toBeNull();
+  });
+
+  it('keeps legacy password auth during migration and scopes admin auth', () => {
+    process.env.CODEBUDDY_PASSWORD = 'legacy-secret';
+
+    expect(
+      getClientAuthErrorResponse(makeNextRequest('http://localhost/test'))
+        ?.status,
+    ).toBe(401);
+    expect(
+      getClientAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Bearer wrong-secret' },
+        }),
+      )?.status,
+    ).toBe(403);
+    expect(
+      getClientAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Bearer legacy-secret' },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      getAdminAuthErrorResponse(
+        makeNextRequest('http://localhost/admin', {
+          headers: { authorization: 'Bearer legacy-secret' },
+        }),
+      ),
+    ).toBeNull();
+
+    const credential = addCredential({
+      bearer_token: 'token-auth',
+      user_id: 'guard@example.com',
+    });
+    const { secret } = createAccessKey({
+      credentialFilenames: [credential.filename],
+      name: 'Guard Key',
+    });
+
+    expect(
+      getClientAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: `Bearer ${secret}` },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      getAdminAuthErrorResponse(
+        makeNextRequest('http://localhost/admin', {
+          headers: { authorization: `Bearer ${secret}` },
+        }),
+      )?.status,
+    ).toBe(403);
   });
 
   it('covers anthropic auth with x-api-key and bearer', async () => {
@@ -303,6 +360,13 @@ describe('server units', () => {
     fs.writeFileSync(path.join(tempConfigDir, 'access-keys.json'), '{');
     expect(listStoredAccessKeys()).toEqual([]);
     expect(hasAccessKeys()).toBe(false);
+    expect(
+      getClientAuthErrorResponse(
+        makeNextRequest('http://localhost/test', {
+          headers: { authorization: 'Bearer anything' },
+        }),
+      )?.status,
+    ).toBe(503);
   });
 
   it('covers access key validation, normalization, and deletion', () => {


### PR DESCRIPTION
## Summary
- add server-managed access keys that are generated by the app instead of entered manually
- allow each access key to bind one or more saved credentials and route requests only within that subset
- remove the old password and rotation-count settings in favor of per-request round-robin routing

## Details
- add admin APIs and UI for creating, editing, deleting, and revealing access keys
- protect `/v1/*` and `/api/settings` with access-key auth once at least one access key exists
- keep the API open when no access keys have been created yet for initial setup
- select credentials by filename and rotate per request across the bound credentials for the active key
- update runtime and unit coverage for the new auth and routing behavior

## Verification
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:coverage`
- `bun run build`