### PR TITLE
fix: avoid invalid secret checks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Detect Docker Hub credentials
+        id: dockerhub
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_PASSWORD}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_PASSWORD != '' }}
+        if: ${{ steps.dockerhub.outputs.enabled == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- repair the release workflow so GitHub Actions accepts the file again
- detect Docker Hub credentials in a shell step and gate Docker Hub login from that output
- keep the existing behavior of pushing latest/version tags to GHCR and optionally to Docker Hub

## Root cause
- PR #17 used a secrets-based expression directly in a step-level if condition
- GitHub rejected the workflow before jobs were created and marked the run as a workflow file issue

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage
- bun run build
