### PR TITLE
ci: build release images natively per architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,16 +111,23 @@ jobs:
     needs:
       - prepare
       - verify
-    name: Publish multi-arch image
-    runs-on: ubuntu-latest
+    name: Publish ${{ matrix.arch }} image
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runs_on: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runs_on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -166,14 +173,14 @@ jobs:
           set -euo pipefail
 
           tags=(
-            "${GHCR_IMAGE}:${VERSION}"
-            "${GHCR_IMAGE}:latest"
+            "${GHCR_IMAGE}:${VERSION}-${{ matrix.arch }}"
+            "${GHCR_IMAGE}:latest-${{ matrix.arch }}"
           )
 
           if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_PASSWORD}" ]]; then
             tags+=(
-              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:${VERSION}"
-              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:latest"
+              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:${VERSION}-${{ matrix.arch }}"
+              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:latest-${{ matrix.arch }}"
             )
           fi
 
@@ -186,18 +193,83 @@ jobs:
       - name: Build and push release image
         uses: docker/build-push-action@v6
         with:
-          cache-from: type=gha,scope=codebuddy2api-docker
-          cache-to: type=gha,mode=max,scope=codebuddy2api-docker
+          cache-from: type=gha,scope=codebuddy2api-docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=codebuddy2api-docker-${{ matrix.arch }}
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+
+  merge-image-manifests:
+    needs:
+      - prepare
+      - publish-image
+    name: Merge multi-arch manifests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Detect Docker Hub credentials
+        id: dockerhub
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_PASSWORD}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to Docker Hub
+        if: ${{ steps.dockerhub.outputs.enabled == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Create multi-arch manifests
+        shell: bash
+        env:
+          GHCR_IMAGE: ${{ needs.prepare.outputs.image }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            -t "${GHCR_IMAGE}:${VERSION}" \
+            -t "${GHCR_IMAGE}:latest" \
+            "${GHCR_IMAGE}:${VERSION}-amd64" \
+            "${GHCR_IMAGE}:${VERSION}-arm64"
+
+          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_PASSWORD}" ]]; then
+            docker buildx imagetools create \
+              -t "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:${VERSION}" \
+              -t "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:latest" \
+              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:${VERSION}-amd64" \
+              "docker.io/${DOCKERHUB_USERNAME}/codebuddy2api:${VERSION}-arm64"
+          fi
 
   release:
     needs:
       - prepare
-      - publish-image
+      - merge-image-manifests
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary
- split release image publishing into parallel native amd64 and arm64 jobs
- run arm64 builds on an ARM GitHub-hosted runner instead of QEMU emulation
- merge the per-architecture images into the existing multi-arch tags before creating the release

## Testing
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage
- bun run build
