### PR TITLE
fix: install Docker native build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM oven/bun:1-slim AS deps
 
 WORKDIR /app
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends --yes python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- install Python and C/C++ build prerequisites in the Docker dependency stage
- allow `better-sqlite3` to rebuild when Bun has no compatible prebuilt binary

## Validation
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:coverage` (94.13%)
- `bun run build`

Local Docker verification could not run because the Docker daemon is not running; the PR Actions Docker job validates that path.