### PR TITLE
fix: keep credential affinity within sessions

### DIFF
--- a/lib/server/domain/credentials.ts
+++ b/lib/server/domain/credentials.ts
@@ -290,6 +290,18 @@ export const findCredentialRecordByFilename = async (
   );
 };
 
+export const findEligibleCredentialRecordByFilename = async (
+  filename: string,
+  allowedCredentialFilenames?: string[],
+): Promise<CredentialRecord | null> => {
+  return (
+    getEligibleRecords(
+      await readCredentialRecords(),
+      allowedCredentialFilenames,
+    ).find((record) => record.filename === filename) ?? null
+  );
+};
+
 const getCredentialExpiry = (credential: CredentialData): number | null => {
   if (
     typeof credential.created_at !== 'number' ||

--- a/lib/server/domain/credentials.ts
+++ b/lib/server/domain/credentials.ts
@@ -42,6 +42,13 @@ export interface CredentialRecord {
 interface ManagerState {
   globalNextFilename: string | null;
   keyNextFilenameByAccessKeyId: Record<string, string | null>;
+  affinityAssignmentsByKey: Record<
+    string,
+    {
+      credentialFilename: string;
+      updatedAt: number;
+    }
+  >;
 }
 
 const globalCredentialState = globalThis as typeof globalThis & {
@@ -51,6 +58,8 @@ const globalCredentialState = globalThis as typeof globalThis & {
 const MANAGER_STATE_FILENAME = 'manager_state.json';
 const RUNTIME_STATE_FLUSH_INTERVAL_MS = 1000;
 const MAX_PENDING_ROTATIONS = 100;
+const AFFINITY_ASSIGNMENT_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_AFFINITY_ASSIGNMENTS = 5_000;
 let pendingRotationCount = 0;
 let runtimeStateFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -63,10 +72,53 @@ const loadPersistedManagerState = async (): Promise<Partial<ManagerState>> => {
   );
 };
 
+const pruneAffinityAssignments = (
+  assignments: unknown,
+): ManagerState['affinityAssignmentsByKey'] => {
+  if (!assignments || typeof assignments !== 'object') {
+    return {};
+  }
+
+  const expiresBefore = Date.now() - AFFINITY_ASSIGNMENT_TTL_MS;
+  const normalizedEntries = Object.entries(
+    assignments as Record<string, unknown>,
+  ).flatMap(([key, value]) => {
+    if (!value || typeof value !== 'object') {
+      return [];
+    }
+
+    const credentialFilename = String(
+      (value as Record<string, unknown>).credentialFilename ?? '',
+    ).trim();
+    const updatedAt = Number((value as Record<string, unknown>).updatedAt);
+
+    if (!credentialFilename || !Number.isFinite(updatedAt)) {
+      return [];
+    }
+
+    if (updatedAt <= expiresBefore) {
+      return [];
+    }
+
+    return [[key, { credentialFilename, updatedAt }] as const];
+  });
+
+  normalizedEntries.sort(
+    (left, right) => right[1].updatedAt - left[1].updatedAt,
+  );
+
+  return Object.fromEntries(
+    normalizedEntries.slice(0, MAX_AFFINITY_ASSIGNMENTS),
+  );
+};
+
 const getRuntimeState = async (): Promise<ManagerState> => {
   if (!globalCredentialState.__codebuddy2apiCredentialState__) {
     const persisted = await loadPersistedManagerState();
     globalCredentialState.__codebuddy2apiCredentialState__ = {
+      affinityAssignmentsByKey: pruneAffinityAssignments(
+        persisted.affinityAssignmentsByKey,
+      ),
       globalNextFilename: persisted.globalNextFilename ?? null,
       keyNextFilenameByAccessKeyId:
         persisted.keyNextFilenameByAccessKeyId ?? {},
@@ -78,7 +130,11 @@ const getRuntimeState = async (): Promise<ManagerState> => {
 
 const saveRuntimeState = async (): Promise<void> => {
   const state = await getRuntimeState();
+  state.affinityAssignmentsByKey = pruneAffinityAssignments(
+    state.affinityAssignmentsByKey,
+  );
   await writeStorageJson('credentials', 'manager_state.json', {
+    affinityAssignmentsByKey: state.affinityAssignmentsByKey,
     globalNextFilename: state.globalNextFilename,
     keyNextFilenameByAccessKeyId: state.keyNextFilenameByAccessKeyId,
     savedAt: Math.floor(Date.now() / 1000),
@@ -514,6 +570,11 @@ export const deleteCredentialByIndex = async (
       state.keyNextFilenameByAccessKeyId[key] = null;
     }
   });
+  Object.entries(state.affinityAssignmentsByKey).forEach(([key, value]) => {
+    if (value.credentialFilename === deletedFilename) {
+      delete state.affinityAssignmentsByKey[key];
+    }
+  });
   await saveRuntimeState();
 
   return { message: 'Credential deleted', success: true };
@@ -570,9 +631,11 @@ export const toggleAutoRotation = (): {
 
 export const resolveCredentialForRequest = async ({
   accessKeyId,
+  affinityKey,
   allowedCredentialFilenames,
 }: {
   accessKeyId?: string;
+  affinityKey?: string;
   allowedCredentialFilenames?: string[];
 } = {}): Promise<CredentialRecord | null> => {
   const records = await readCredentialRecords();
@@ -586,6 +649,30 @@ export const resolveCredentialForRequest = async ({
   }
 
   const state = await getRuntimeState();
+  state.affinityAssignmentsByKey = pruneAffinityAssignments(
+    state.affinityAssignmentsByKey,
+  );
+
+  if (affinityKey) {
+    const assignment = state.affinityAssignmentsByKey[affinityKey];
+    const assignedRecord = eligibleRecords.find(
+      (record) => record.filename === assignment?.credentialFilename,
+    );
+
+    if (assignedRecord) {
+      state.affinityAssignmentsByKey[affinityKey] = {
+        credentialFilename: assignedRecord.filename,
+        updatedAt: Date.now(),
+      };
+      scheduleRuntimeStateSave();
+      return assignedRecord;
+    }
+
+    if (assignment) {
+      delete state.affinityAssignmentsByKey[affinityKey];
+    }
+  }
+
   const currentNextFilename = accessKeyId
     ? (state.keyNextFilenameByAccessKeyId[accessKeyId] ?? null)
     : state.globalNextFilename;
@@ -598,6 +685,13 @@ export const resolveCredentialForRequest = async ({
     state.keyNextFilenameByAccessKeyId[accessKeyId] = nextFilename;
   } else {
     state.globalNextFilename = nextFilename;
+  }
+
+  if (affinityKey) {
+    state.affinityAssignmentsByKey[affinityKey] = {
+      credentialFilename: current.filename,
+      updatedAt: Date.now(),
+    };
   }
 
   scheduleRuntimeStateSave();

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -8,6 +8,7 @@ import {
 } from '../domain/config';
 import {
   type CredentialRecord,
+  findEligibleCredentialRecordByFilename,
   findCredentialRecordByFilename,
   getCredentialProxySettings,
   resolveCredentialForRequest,
@@ -416,12 +417,21 @@ export const createProxyContextFromCredential = (
 
 export const resolveProxyContextByCredentialFilename = async (
   filename: string,
-  accessKey?: {
-    id?: string | null;
-    name?: string | null;
+  options?: {
+    accessKey?: {
+      id?: string | null;
+      name?: string | null;
+    };
+    allowedCredentialFilenames?: string[];
+    requireEligible?: boolean;
   },
 ): Promise<ProxyContext> => {
-  const credential = await findCredentialRecordByFilename(filename);
+  const credential = options?.requireEligible
+    ? await findEligibleCredentialRecordByFilename(
+        filename,
+        options.allowedCredentialFilenames,
+      )
+    : await findCredentialRecordByFilename(filename);
 
   if (!credential) {
     throw new Error('Selected credential was not found');
@@ -429,8 +439,8 @@ export const resolveProxyContextByCredentialFilename = async (
 
   return {
     ...createProxyContextFromCredential(credential),
-    accessKeyId: accessKey?.id ?? null,
-    accessKeyName: accessKey?.name ?? null,
+    accessKeyId: options?.accessKey?.id ?? null,
+    accessKeyName: options?.accessKey?.name ?? null,
   };
 };
 

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -106,6 +106,24 @@ export interface ProxyContext {
   };
 }
 
+const getCredentialAffinityKey = (
+  request: NextRequest,
+  accessKeyId: string | null,
+): string | undefined => {
+  const incoming = getRequestHeaderMap(request.headers);
+  const conversationId = incoming['x-conversation-id']?.trim();
+
+  if (!conversationId) {
+    return undefined;
+  }
+
+  if (accessKeyId) {
+    return `access-key:${accessKeyId}:conversation:${conversationId}`;
+  }
+
+  return `global:conversation:${conversationId}`;
+};
+
 const toUsageSnapshot = (usage: unknown): UsageSnapshot | null => {
   if (!usage || typeof usage !== 'object') {
     return null;
@@ -341,6 +359,7 @@ export const resolveProxyContext = async (
   const accessKey = await resolveRequestAccessKey(request);
   const credential = await resolveCredentialForRequest({
     accessKeyId: accessKey?.id,
+    affinityKey: getCredentialAffinityKey(request, accessKey?.id ?? null),
     allowedCredentialFilenames: accessKey?.credentialFilenames,
   });
 
@@ -397,6 +416,10 @@ export const createProxyContextFromCredential = (
 
 export const resolveProxyContextByCredentialFilename = async (
   filename: string,
+  accessKey?: {
+    id?: string | null;
+    name?: string | null;
+  },
 ): Promise<ProxyContext> => {
   const credential = await findCredentialRecordByFilename(filename);
 
@@ -404,7 +427,11 @@ export const resolveProxyContextByCredentialFilename = async (
     throw new Error('Selected credential was not found');
   }
 
-  return createProxyContextFromCredential(credential);
+  return {
+    ...createProxyContextFromCredential(credential),
+    accessKeyId: accessKey?.id ?? null,
+    accessKeyName: accessKey?.name ?? null,
+  };
 };
 
 const getCredentialValue = (

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -1373,30 +1373,41 @@ export const handleResponsesRequest = async (
   try {
     const previousResponseId = body.previous_response_id ?? null;
     const accessKey = await resolveRequestAccessKey(request);
-    const previousSession = getValidatedPreviousSession(
-      previousResponseId,
-      accessKey?.id ?? null,
-    );
+    const storedPreviousSession = previousResponseId
+      ? getResponseSession(previousResponseId)
+      : undefined;
 
     if (
-      previousSession?.credentialFilename &&
+      previousResponseId &&
+      storedPreviousSession &&
+      storedPreviousSession.accessKeyId !== (accessKey?.id ?? null)
+    ) {
+      throw new Error('Unknown or expired previous_response_id');
+    }
+
+    if (
+      storedPreviousSession?.credentialFilename &&
       accessKey?.credentialFilenames?.length &&
       !accessKey.credentialFilenames.includes(
-        previousSession.credentialFilename,
+        storedPreviousSession.credentialFilename,
       )
     ) {
       throw new Error('Unknown or expired previous_response_id');
     }
 
-    const proxyContext = previousSession?.credentialFilename
+    const proxyContext = storedPreviousSession?.credentialFilename
       ? await resolveProxyContextByCredentialFilename(
-          previousSession.credentialFilename,
-          accessKey
-            ? {
-                id: accessKey.id,
-                name: accessKey.name,
-              }
-            : undefined,
+          storedPreviousSession.credentialFilename,
+          {
+            accessKey: accessKey
+              ? {
+                  id: accessKey.id,
+                  name: accessKey.name,
+                }
+              : undefined,
+            allowedCredentialFilenames: accessKey?.credentialFilenames,
+            requireEligible: true,
+          },
         )
       : await resolveProxyContext(request);
 
@@ -1408,6 +1419,11 @@ export const handleResponsesRequest = async (
         debugTrace,
       );
     }
+
+    const previousSession = getValidatedPreviousSession(
+      previousResponseId,
+      accessKey?.id ?? null,
+    );
 
     const prepared = await prepareTranscript(
       body,

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -6,8 +6,10 @@ import {
   proxyChatCompletions,
   proxyResponsesUpstream,
   resolveProxyContext,
+  resolveProxyContextByCredentialFilename,
   type ProxyContext,
 } from './codebuddy';
+import { resolveRequestAccessKey } from './auth';
 import { createErrorResponse } from '../shared/http';
 
 interface ResponsesInputItem {
@@ -52,6 +54,7 @@ type ResponseSessionDefaults = Pick<
 
 interface ResponseSession {
   accessKeyId: string | null;
+  credentialFilename: string | null;
   createdAt: number;
   id: string;
   model: string;
@@ -151,6 +154,24 @@ const pruneResponseSessions = (): void => {
 const getResponseSession = (id: string): ResponseSession | undefined => {
   pruneResponseSessions();
   return getSessionStore().get(id);
+};
+
+const getValidatedPreviousSession = (
+  previousResponseId: string | null,
+  accessKeyId: string | null,
+): ResponseSession | undefined => {
+  const previousSession = previousResponseId
+    ? getResponseSession(previousResponseId)
+    : undefined;
+
+  if (
+    previousResponseId &&
+    (!previousSession || previousSession.accessKeyId !== accessKeyId)
+  ) {
+    throw new Error('Unknown or expired previous_response_id');
+  }
+
+  return previousSession;
 };
 
 const storeResponseSession = (session: ResponseSession): void => {
@@ -774,6 +795,7 @@ const getStreamingToolCallLookupKeys = (
 const prepareTranscript = async (
   body: ResponsesRequestBody,
   accessKeyId: string | null,
+  previousSession?: ResponseSession,
 ): Promise<{
   defaults: ResponseSessionDefaults;
   model: string;
@@ -781,29 +803,27 @@ const prepareTranscript = async (
   previousResponseId: string | null;
 }> => {
   const previousResponseId = body.previous_response_id ?? null;
-  const previousSession = previousResponseId
-    ? getResponseSession(previousResponseId)
-    : undefined;
+  const resolvedPreviousSession =
+    previousSession ??
+    getValidatedPreviousSession(previousResponseId, accessKeyId);
 
-  if (
-    previousResponseId &&
-    (!previousSession || previousSession.accessKeyId !== accessKeyId)
-  ) {
-    throw new Error('Unknown or expired previous_response_id');
-  }
-
-  const transcript = [...(previousSession?.transcript ?? [])];
+  const transcript = [...(resolvedPreviousSession?.transcript ?? [])];
   const model =
     typeof body.model === 'string' && body.model.trim()
       ? body.model
-      : (previousSession?.model ?? (await getDefaultModel()));
+      : (resolvedPreviousSession?.model ?? (await getDefaultModel()));
   const defaults = {
     instructions:
-      body.instructions ?? previousSession?.defaults.instructions ?? undefined,
-    metadata: body.metadata ?? previousSession?.defaults.metadata ?? undefined,
-    tools: body.tools ?? previousSession?.defaults.tools ?? undefined,
+      body.instructions ??
+      resolvedPreviousSession?.defaults.instructions ??
+      undefined,
+    metadata:
+      body.metadata ?? resolvedPreviousSession?.defaults.metadata ?? undefined,
+    tools: body.tools ?? resolvedPreviousSession?.defaults.tools ?? undefined,
     tool_choice:
-      body.tool_choice ?? previousSession?.defaults.tool_choice ?? undefined,
+      body.tool_choice ??
+      resolvedPreviousSession?.defaults.tool_choice ??
+      undefined,
   };
 
   if (body.messages?.length) {
@@ -860,6 +880,7 @@ const normalizeTranscriptMessageToolNames = (
 
 const mapChatResponseToResponsesPayload = (
   accessKeyId: string | null,
+  credentialFilename: string | null,
   defaults: ResponseSessionDefaults,
   transcript: TranscriptMessage[],
   model: string,
@@ -914,6 +935,7 @@ const mapChatResponseToResponsesPayload = (
 
   storeResponseSession({
     accessKeyId,
+    credentialFilename,
     createdAt: Date.now(),
     id: responseId,
     model,
@@ -1117,6 +1139,7 @@ const createResponsesEventStream = async (
             );
           storeResponseSession({
             accessKeyId: proxyContext?.accessKeyId ?? null,
+            credentialFilename: proxyContext?.credentialFilename ?? null,
             createdAt: Date.now(),
             id: responseId,
             model,
@@ -1348,7 +1371,34 @@ export const handleResponsesRequest = async (
   debugTrace?: DebugTrace,
 ): Promise<Response> => {
   try {
-    const proxyContext = await resolveProxyContext(request);
+    const previousResponseId = body.previous_response_id ?? null;
+    const accessKey = await resolveRequestAccessKey(request);
+    const previousSession = getValidatedPreviousSession(
+      previousResponseId,
+      accessKey?.id ?? null,
+    );
+
+    if (
+      previousSession?.credentialFilename &&
+      accessKey?.credentialFilenames?.length &&
+      !accessKey.credentialFilenames.includes(
+        previousSession.credentialFilename,
+      )
+    ) {
+      throw new Error('Unknown or expired previous_response_id');
+    }
+
+    const proxyContext = previousSession?.credentialFilename
+      ? await resolveProxyContextByCredentialFilename(
+          previousSession.credentialFilename,
+          accessKey
+            ? {
+                id: accessKey.id,
+                name: accessKey.name,
+              }
+            : undefined,
+        )
+      : await resolveProxyContext(request);
 
     if (proxyContext.preferences.responsesPassthrough) {
       return proxyResponsesUpstream(
@@ -1359,7 +1409,11 @@ export const handleResponsesRequest = async (
       );
     }
 
-    const prepared = await prepareTranscript(body, proxyContext.accessKeyId);
+    const prepared = await prepareTranscript(
+      body,
+      proxyContext.accessKeyId,
+      previousSession,
+    );
     const compatibilityError = getResponsesCompatibilityError(
       prepared.defaults.tools,
       prepared.defaults.tool_choice,
@@ -1422,6 +1476,7 @@ export const handleResponsesRequest = async (
     return Response.json(
       mapChatResponseToResponsesPayload(
         proxyContext.accessKeyId,
+        proxyContext.credentialFilename,
         prepared.defaults,
         prepared.transcript,
         prepared.model,

--- a/tests/server/runtime.test.ts
+++ b/tests/server/runtime.test.ts
@@ -785,6 +785,106 @@ describe('server runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps one responses session on the original credential within a pooled access key', async () => {
+    const firstCredential = await (
+      await AdminCredentialsRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/credentials', {
+          bearer_token: 'responses-affinity-first-token',
+          user_id: 'responses-affinity-first@example.com',
+        }),
+      )
+    ).json();
+    const secondCredential = await (
+      await AdminCredentialsRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/credentials', {
+          bearer_token: 'responses-affinity-second-token',
+          user_id: 'responses-affinity-second@example.com',
+        }),
+      )
+    ).json();
+    const accessKey = await (
+      await AdminAccessKeysRoute.POST(
+        makeJsonRequest('http://localhost/admin-api/access-keys', {
+          credential_filenames: [
+            firstCredential.filename,
+            secondCredential.filename,
+          ],
+          name: 'Responses Affinity Key',
+        }),
+      )
+    ).json();
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeSseResponse([
+          'data: {"choices":[{"delta":{"content":"first"}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":" answer"},"finish_reason":"stop"}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(
+        makeSseResponse([
+          'data: {"choices":[{"delta":{"content":"second"}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":" answer"},"finish_reason":"stop"}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(
+        makeSseResponse([
+          'data: {"choices":[{"delta":{"content":"third"}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":" answer"},"finish_reason":"stop"}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      );
+
+    const firstResponse = await V1ResponsesRoute.POST(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${accessKey.secret}` },
+        body: JSON.stringify({ input: 'hello', model: 'glm-5.1' }),
+      }),
+    );
+    const firstPayload = await firstResponse.json();
+    const secondResponse = await V1ResponsesRoute.POST(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${accessKey.secret}` },
+        body: JSON.stringify({
+          input: 'continue',
+          previous_response_id: firstPayload.id,
+        }),
+      }),
+    );
+    const thirdResponse = await V1ResponsesRoute.POST(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${accessKey.secret}` },
+        body: JSON.stringify({ input: 'new thread', model: 'glm-5.1' }),
+      }),
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(thirdResponse.status).toBe(200);
+
+    const firstHeaders = (fetchMock.mock.calls[0]?.[1] as RequestInit)
+      .headers as Headers;
+    const secondHeaders = (fetchMock.mock.calls[1]?.[1] as RequestInit)
+      .headers as Headers;
+    const thirdHeaders = (fetchMock.mock.calls[2]?.[1] as RequestInit)
+      .headers as Headers;
+
+    expect(firstHeaders.get('Authorization')).toBe(
+      'Bearer responses-affinity-first-token',
+    );
+    expect(secondHeaders.get('Authorization')).toBe(
+      'Bearer responses-affinity-first-token',
+    );
+    expect(thirdHeaders.get('Authorization')).toBe(
+      'Bearer responses-affinity-second-token',
+    );
+  });
+
   it('supports codebuddy auth start, poll, callback, and protected api settings', async () => {
     const jwtPayload = Buffer.from(
       JSON.stringify({

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -496,6 +496,54 @@ describe('server units', () => {
     expect((await getUsageStats()).credential_usage['cred-a']).toBeUndefined();
   });
 
+  it('keeps affinity assignments stable and clears them when credentials disappear', async () => {
+    while ((await deleteCredentialByIndex(0)).success) {
+      // clear seeded credentials to make affinity selection deterministic
+    }
+
+    const firstCredential = await addCredential({
+      bearer_token: 'token-affinity-1',
+      created_at: Math.floor(Date.now() / 1000),
+      expires_in: 3600,
+      user_id: 'affinity-one@example.com',
+    });
+    const secondCredential = await addCredential({
+      bearer_token: 'token-affinity-2',
+      created_at: Math.floor(Date.now() / 1000),
+      expires_in: 3600,
+      user_id: 'affinity-two@example.com',
+    });
+    const allowedCredentialFilenames = [
+      firstCredential.filename,
+      secondCredential.filename,
+    ];
+
+    const firstResolved = await resolveCredentialForRequest({
+      affinityKey: 'conversation:stable',
+      allowedCredentialFilenames,
+    });
+    const secondResolved = await resolveCredentialForRequest({
+      affinityKey: 'conversation:stable',
+      allowedCredentialFilenames,
+    });
+
+    expect(firstResolved?.filename).toBe(firstCredential.filename);
+    expect(secondResolved?.filename).toBe(firstCredential.filename);
+
+    const listed = await listCredentials();
+    const firstIndex = listed.credentials.findIndex(
+      (credential) => credential.filename === firstCredential.filename,
+    );
+    expect(firstIndex).toBeGreaterThanOrEqual(0);
+    expect((await deleteCredentialByIndex(firstIndex)).success).toBe(true);
+
+    const reassigned = await resolveCredentialForRequest({
+      affinityKey: 'conversation:stable',
+      allowedCredentialFilenames,
+    });
+    expect(reassigned?.filename).toBe(secondCredential.filename);
+  });
+
   it('persists usage history under file storage and preserves historical filters', async () => {
     const now = new Date('2026-07-11T12:30:00.000Z');
 
@@ -2246,6 +2294,46 @@ describe('server units', () => {
     });
   });
 
+  it('does not locally reject previous_response_id for passthrough responses', async () => {
+    const createdCredential = await addCredential({
+      bearer_token: 'token-passthrough-follow-up',
+      responses_passthrough: true,
+      user_id: 'passthrough-follow-up@example.com',
+    });
+    const accessKey = await createAccessKey({
+      credentialFilenames: [createdCredential.filename],
+      name: 'Passthrough Follow-up Key',
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeJsonResponse({
+        id: 'resp_upstream',
+        object: 'response',
+        output_text: 'continued upstream',
+      }),
+    );
+
+    const response = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessKey.secret}`,
+        },
+      }),
+      {
+        input: 'continue remotely',
+        model: 'gpt-5.5',
+        previous_response_id: 'resp_from_upstream',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit).body))
+        .previous_response_id,
+    ).toBe('resp_from_upstream');
+  });
+
   it('covers proxy context helpers for saved credentials', async () => {
     const createdCredential = await addCredential({
       bearer_token: 'token-from-bearer-token',
@@ -2272,6 +2360,19 @@ describe('server units', () => {
     );
     expect(resolved.credentialFilename).toBe(createdCredential.filename);
     expect(resolved.auth.userId).toBe('helper@example.com');
+
+    const expiredCredential = await addCredential({
+      bearer_token: 'token-expired-helper',
+      created_at: 1,
+      expires_in: 1,
+      user_id: 'expired-helper@example.com',
+    });
+    await expect(
+      resolveProxyContextByCredentialFilename(expiredCredential.filename, {
+        requireEligible: true,
+      }),
+    ).rejects.toThrow('Selected credential was not found');
+
     expect(
       createProxyContextFromCredential({
         data: {
@@ -2294,6 +2395,69 @@ describe('server units', () => {
     await expect(
       resolveProxyContextByCredentialFilename('missing.json'),
     ).rejects.toThrow('Selected credential was not found');
+  });
+
+  it('stops local responses follow-ups when the pinned credential is no longer eligible', async () => {
+    const createdCredential = await addCredential({
+      bearer_token: 'token-local-follow-up',
+      responses_passthrough: false,
+      user_id: 'local-follow-up@example.com',
+    });
+    const listedBefore = await listCredentials();
+    const targetIndex = listedBefore.credentials.findIndex(
+      (credential) => credential.filename === createdCredential.filename,
+    );
+    const accessKey = await createAccessKey({
+      credentialFilenames: [createdCredential.filename],
+      name: 'Local Follow-up Key',
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeJsonResponse({
+        choices: [{ message: { content: 'stored locally' } }],
+        model: 'gpt-5.5',
+      }),
+    );
+
+    const firstResponse = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessKey.secret}`,
+        },
+      }),
+      {
+        input: 'start local session',
+        model: 'gpt-5.5',
+      },
+    );
+    const firstPayload = (await firstResponse.json()) as { id: string };
+
+    await updateCredentialByIndex(targetIndex, {
+      bearer_token: 'token-local-follow-up',
+      expires_in: -1,
+      responses_passthrough: false,
+      user_id: 'local-follow-up@example.com',
+    });
+
+    const followUpResponse = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessKey.secret}`,
+        },
+      }),
+      {
+        input: 'continue local session',
+        previous_response_id: firstPayload.id,
+      },
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(followUpResponse.status).toBe(500);
+    expect(await followUpResponse.text()).toContain(
+      'Selected credential was not found',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('updates saved credentials by index and normalizes string boolean flags', async () => {

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -1251,6 +1251,115 @@ describe('server units', () => {
     ]);
   });
 
+  it('keeps the same credential for one conversation id across chat requests', async () => {
+    await addCredential({
+      bearer_token: 'token-conv-a',
+      created_at: Math.floor(Date.now() / 1000),
+      first_message_role_to_system: false,
+      user_id: 'conversation-a@example.com',
+    });
+    await addCredential({
+      bearer_token: 'token-conv-b',
+      created_at: Math.floor(Date.now() / 1000),
+      first_message_role_to_system: true,
+      user_id: 'conversation-b@example.com',
+    });
+
+    const conversationCredentials = (
+      await listCredentials()
+    ).credentials.filter(
+      (credential) =>
+        credential.user_id === 'conversation-a@example.com' ||
+        credential.user_id === 'conversation-b@example.com',
+    );
+    const roleAccessKey = await createAccessKey({
+      credentialFilenames: conversationCredentials.map((credential) =>
+        String(credential.filename),
+      ),
+      name: 'Conversation Affinity Key',
+    });
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      return Promise.resolve(
+        makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+      );
+    });
+
+    const firstResponse = await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${roleAccessKey.secret}`,
+          'X-Conversation-ID': 'conversation-a',
+        },
+      }),
+      {
+        messages: [{ role: 'developer', content: 'keep role stable' }],
+        stream: false,
+      },
+    );
+    const secondResponse = await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${roleAccessKey.secret}`,
+          'X-Conversation-ID': 'conversation-a',
+        },
+      }),
+      {
+        messages: [{ role: 'developer', content: 'same conversation' }],
+        stream: false,
+      },
+    );
+    const thirdResponse = await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${roleAccessKey.secret}`,
+          'X-Conversation-ID': 'conversation-b',
+        },
+      }),
+      {
+        messages: [{ role: 'developer', content: 'different conversation' }],
+        stream: false,
+      },
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(thirdResponse.status).toBe(200);
+
+    const firstBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as {
+      messages: Array<{
+        content: string;
+        role: string;
+      }>;
+    };
+    const secondBody = JSON.parse(
+      String((fetchMock.mock.calls[1]?.[1] as RequestInit).body),
+    ) as {
+      messages: Array<{
+        content: string;
+        role: string;
+      }>;
+    };
+    const thirdBody = JSON.parse(
+      String((fetchMock.mock.calls[2]?.[1] as RequestInit).body),
+    ) as {
+      messages: Array<{
+        content: string;
+        role: string;
+      }>;
+    };
+
+    expect(firstBody.messages[0]?.role).toBe('developer');
+    expect(secondBody.messages[0]?.role).toBe('developer');
+    expect(thirdBody.messages[0]?.role).toBe('system');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it('aggregates forced upstream streaming responses for non-stream clients', async () => {
     process.env.CODEBUDDY_AUTH_MODE = 'api_key';
     process.env.CODEBUDDY_API_KEY = 'cb-key';


### PR DESCRIPTION
## Summary
- keep pooled credentials sticky per conversation when requests provide X-Conversation-ID
- pin /v1/responses follow-up requests to the credential chosen by the initial response session
- add regression tests for chat conversation affinity and responses session affinity

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage
- bun run build