### PR TITLE
fix: use Bun dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary
- configure Dependabot to use the Bun ecosystem for the root dependencies
- allow Dependabot to update `bun.lock` alongside dependency manifests

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage (94.21% statements and lines)
- bun run build