### PR TITLE
fix: improve prompt cache accounting and preserve Anthropic cache-control

### DIFF
--- a/lib/server/domain/usage.ts
+++ b/lib/server/domain/usage.ts
@@ -18,6 +18,10 @@ export type UsageRange =
 export interface UsageSnapshot {
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
+  prompt_tokens_details?: {
+    cached_tokens?: number | null;
+    cache_creation_tokens?: number | null;
+  } | null;
   completion_tokens?: number | null;
   input_tokens?: number | null;
   output_tokens?: number | null;
@@ -126,12 +130,20 @@ const toNumber = (value: unknown): number => {
 const normalizeUsage = (usage: UsageSnapshot): UsageEventRecord => {
   const inputTokens = toNumber(usage.input_tokens ?? usage.prompt_tokens);
   const outputTokens = toNumber(usage.output_tokens ?? usage.completion_tokens);
-  const cacheReadTokens = toNumber(usage.cache_read_input_tokens);
-  const cacheCreationTokens = toNumber(usage.cache_creation_input_tokens);
+  const promptTokenDetails = usage.prompt_tokens_details;
+  const cacheReadTokens = toNumber(
+    usage.cache_read_input_tokens ?? promptTokenDetails?.cached_tokens,
+  );
+  const cacheCreationTokens = toNumber(
+    usage.cache_creation_input_tokens ??
+      promptTokenDetails?.cache_creation_tokens,
+  );
   const explicitTotal = toNumber(usage.total_tokens);
   const totalTokens =
     explicitTotal ||
-    inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
+    inputTokens +
+      outputTokens +
+      (promptTokenDetails ? 0 : cacheReadTokens + cacheCreationTokens);
 
   return {
     accessKeyId: null,

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -110,6 +110,14 @@ interface OpenAIStreamChunk {
   usage?: OpenAIUsage;
 }
 
+interface ChatTextBlock {
+  cache_control?: { type?: string };
+  text: string;
+  type: 'text';
+}
+
+type ChatTextContent = string | ChatTextBlock[];
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -146,9 +154,27 @@ const stringifyContent = (value: unknown): string => {
   return JSON.stringify(value);
 };
 
+const mapTextPartsToChatContent = (
+  parts: Array<string | ChatTextBlock>,
+): ChatTextContent => {
+  const textParts = parts.filter((part) =>
+    typeof part === 'string' ? part.length > 0 : part.text.length > 0,
+  );
+  const hasStructuredText = textParts.some((part) => typeof part !== 'string');
+
+  if (!hasStructuredText) {
+    return textParts.join('\n');
+  }
+
+  return textParts.flatMap((part, index) => [
+    ...(index > 0 ? [{ type: 'text' as const, text: '\n' }] : []),
+    typeof part === 'string' ? { type: 'text' as const, text: part } : part,
+  ]);
+};
+
 const extractSystemText = (
   system: string | AnthropicContentBlock[] | undefined,
-): string => {
+): ChatTextContent => {
   if (!system) {
     return '';
   }
@@ -157,24 +183,24 @@ const extractSystemText = (
     return system;
   }
 
-  return system
-    .map((block) => {
+  return mapTextPartsToChatContent(
+    system.map((block) => {
       if (block.type === 'text') {
-        return block.text ?? '';
+        const text = block.text ?? '';
+
+        return block.cache_control
+          ? { type: 'text', text, cache_control: block.cache_control }
+          : text;
       }
 
       return stringifyContent(block);
-    })
-    .join('\n');
+    }),
+  );
 };
 
 // ---------------------------------------------------------------------------
 // Request translation: Anthropic → OpenAI
 // ---------------------------------------------------------------------------
-
-type ChatTextContent =
-  | string
-  | Array<{ cache_control?: { type?: string }; text: string; type: 'text' }>;
 
 interface ChatMessage {
   role: string;
@@ -202,9 +228,7 @@ const mapAnthropicContentToChat = (
   // the OpenAI upstream receives proper tool_calls / tool messages instead
   // of flattened text. This preserves the call↔result relationship that
   // multi-step tool loops rely on.
-  const parts: Array<
-    string | { cache_control?: { type?: string }; text: string; type: 'text' }
-  > = [];
+  const parts: Array<string | ChatTextBlock> = [];
   const toolCalls: Array<{
     id: string;
     type: string;
@@ -250,15 +274,7 @@ const mapAnthropicContentToChat = (
     }
   }
 
-  const textParts = parts.filter((part) =>
-    typeof part === 'string' ? part.length > 0 : part.text.length > 0,
-  );
-  const hasStructuredText = textParts.some((part) => typeof part !== 'string');
-  const textContent = hasStructuredText
-    ? textParts.map((part) =>
-        typeof part === 'string' ? { type: 'text' as const, text: part } : part,
-      )
-    : textParts.join('\n');
+  const textContent = mapTextPartsToChatContent(parts);
   const messages: ChatMessage[] = [];
 
   // Emit tool results before any free-form text so the tool result stays

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -12,6 +12,7 @@ import { proxyChatCompletions, type ChatRequestBody } from './codebuddy';
 interface AnthropicContentBlock {
   type: string;
   text?: string;
+  cache_control?: { type?: string };
   id?: string;
   name?: string;
   input?: unknown;
@@ -171,9 +172,13 @@ const extractSystemText = (
 // Request translation: Anthropic → OpenAI
 // ---------------------------------------------------------------------------
 
+type ChatTextContent =
+  | string
+  | Array<{ cache_control?: { type?: string }; text: string; type: 'text' }>;
+
 interface ChatMessage {
   role: string;
-  content: string | null;
+  content: ChatTextContent | null;
   tool_calls?: Array<{
     id: string;
     type: string;
@@ -197,7 +202,9 @@ const mapAnthropicContentToChat = (
   // the OpenAI upstream receives proper tool_calls / tool messages instead
   // of flattened text. This preserves the call↔result relationship that
   // multi-step tool loops rely on.
-  const parts: string[] = [];
+  const parts: Array<
+    string | { cache_control?: { type?: string }; text: string; type: 'text' }
+  > = [];
   const toolCalls: Array<{
     id: string;
     type: string;
@@ -210,7 +217,13 @@ const mapAnthropicContentToChat = (
 
   for (const block of content) {
     if (block.type === 'text') {
-      parts.push(block.text ?? '');
+      const text = block.text ?? '';
+
+      parts.push(
+        block.cache_control
+          ? { type: 'text', text, cache_control: block.cache_control }
+          : text,
+      );
     } else if (block.type === 'tool_use') {
       toolCalls.push({
         id: block.id ?? createAnthropicId('toolu'),
@@ -237,7 +250,15 @@ const mapAnthropicContentToChat = (
     }
   }
 
-  const textContent = parts.filter(Boolean).join('\n');
+  const textParts = parts.filter((part) =>
+    typeof part === 'string' ? part.length > 0 : part.text.length > 0,
+  );
+  const hasStructuredText = textParts.some((part) => typeof part !== 'string');
+  const textContent = hasStructuredText
+    ? textParts.map((part) =>
+        typeof part === 'string' ? { type: 'text' as const, text: part } : part,
+      )
+    : textParts.join('\n');
   const messages: ChatMessage[] = [];
 
   // Emit tool results before any free-form text so the tool result stays
@@ -253,10 +274,15 @@ const mapAnthropicContentToChat = (
   if (role === 'assistant') {
     messages.push({
       role: 'assistant',
-      content: textContent || null,
+      content:
+        Array.isArray(textContent) && textContent.length === 0
+          ? null
+          : textContent || null,
       ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
     });
-  } else if (textContent) {
+  } else if (
+    Array.isArray(textContent) ? textContent.length > 0 : textContent
+  ) {
     messages.push({ role: 'user', content: textContent });
   }
 

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -336,10 +336,6 @@ const createCacheableTextBlock = (text: string): CacheableTextBlock => ({
 });
 
 const addPromptCacheControl = (message: OpenAIMessage): OpenAIMessage => {
-  if (hasPromptCacheControl(message.content)) {
-    return message;
-  }
-
   if (
     typeof message.content === 'string' &&
     message.content.trim().length >= MIN_AUTO_CACHE_TEXT_LENGTH

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -30,6 +30,14 @@ interface OpenAIMessage {
   tool_call_id?: string;
 }
 
+interface CacheableTextBlock {
+  cache_control?: { type: 'ephemeral' };
+  text: string;
+  type: 'text';
+}
+
+const MIN_AUTO_CACHE_TEXT_LENGTH = 1024;
+
 export interface ChatRequestBody {
   model?: string;
   messages?: OpenAIMessage[];
@@ -312,6 +320,107 @@ const logUpstreamFailure = ({
   console.error('[CodeBuddy2API] Upstream request failed', payload);
 };
 
+const hasPromptCacheControl = (content: unknown): boolean => {
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (part) => !!part && typeof part === 'object' && 'cache_control' in part,
+    )
+  );
+};
+
+const createCacheableTextBlock = (text: string): CacheableTextBlock => ({
+  type: 'text',
+  text,
+  cache_control: { type: 'ephemeral' },
+});
+
+const addPromptCacheControl = (message: OpenAIMessage): OpenAIMessage => {
+  if (hasPromptCacheControl(message.content)) {
+    return message;
+  }
+
+  if (
+    typeof message.content === 'string' &&
+    message.content.trim().length >= MIN_AUTO_CACHE_TEXT_LENGTH
+  ) {
+    return {
+      ...message,
+      content: [createCacheableTextBlock(message.content)],
+    };
+  }
+
+  if (Array.isArray(message.content)) {
+    const textIndex = message.content.findIndex(
+      (part) =>
+        !!part &&
+        typeof part === 'object' &&
+        (part as { type?: unknown }).type === 'text' &&
+        typeof (part as { text?: unknown }).text === 'string' &&
+        (part as { text: string }).text.trim().length >=
+          MIN_AUTO_CACHE_TEXT_LENGTH,
+    );
+
+    if (textIndex >= 0) {
+      return {
+        ...message,
+        content: message.content.map((part, index) =>
+          index === textIndex && part && typeof part === 'object'
+            ? {
+                ...part,
+                cache_control: { type: 'ephemeral' },
+              }
+            : part,
+        ),
+      };
+    }
+  }
+
+  return message;
+};
+
+const applyPromptCacheControl = (
+  messages: OpenAIMessage[],
+): OpenAIMessage[] => {
+  const explicitCacheControl = messages.some((message) =>
+    hasPromptCacheControl(message.content),
+  );
+
+  if (explicitCacheControl) {
+    return messages;
+  }
+
+  const cacheableIndexes = new Set<number>();
+  const systemIndex = messages.findIndex(
+    (message) => message.role === 'system',
+  );
+
+  if (systemIndex >= 0) {
+    cacheableIndexes.add(systemIndex);
+  }
+
+  let lastUserIndex = -1;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === 'user') {
+      lastUserIndex = index;
+      break;
+    }
+  }
+
+  if (lastUserIndex >= 0) {
+    cacheableIndexes.add(lastUserIndex);
+  }
+
+  if (cacheableIndexes.size === 0) {
+    return messages;
+  }
+
+  return messages.map((message, index) =>
+    cacheableIndexes.has(index) ? addPromptCacheControl(message) : message,
+  );
+};
+
 const normalizeMessages = (
   messages: OpenAIMessage[],
   firstMessageRoleToSystem: boolean,
@@ -321,12 +430,12 @@ const normalizeMessages = (
   );
 
   if (!firstMessageRoleToSystem) {
-    return filtered;
+    return applyPromptCacheControl(filtered);
   }
 
   let hasSystemMessage = false;
 
-  return filtered.map((message, index) => {
+  const normalized = filtered.map((message, index) => {
     if (message.role === 'system') {
       hasSystemMessage = true;
       return message;
@@ -352,6 +461,7 @@ const normalizeMessages = (
 
   // Preserve role:'tool' messages so the OpenAI-compatible upstream
   // receives a valid tool_calls/tool-result pair for multi-step tool loops.
+  return applyPromptCacheControl(normalized);
 };
 
 export const resolveProxyContext = async (

--- a/tests/server/anthropic.test.ts
+++ b/tests/server/anthropic.test.ts
@@ -139,6 +139,51 @@ describe('anthropic messages api', () => {
     expect(upstreamBody.stream).toBe(true);
   });
 
+  it('preserves explicit Anthropic cache control blocks upstream', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+      );
+
+    const response = await handleMessagesRequest(
+      makeNextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        model: 'claude-sonnet-4.6',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Reusable prompt prefix',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const upstreamBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown; role: string }> };
+
+    expect(upstreamBody.messages[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Reusable prompt prefix',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    });
+  });
+
   it('translates tool_use blocks in non-streaming response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       makeJsonResponse({

--- a/tests/server/anthropic.test.ts
+++ b/tests/server/anthropic.test.ts
@@ -184,6 +184,91 @@ describe('anthropic messages api', () => {
     });
   });
 
+  it('preserves cache control blocks in top-level system content', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+      );
+
+    await handleMessagesRequest(
+      makeNextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        model: 'claude-sonnet-4.6',
+        max_tokens: 1024,
+        system: [
+          {
+            type: 'text',
+            text: 'Reusable system prefix',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+        messages: [{ role: 'user', content: 'Question' }],
+      },
+    );
+
+    const upstreamBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown; role: string }> };
+
+    expect(upstreamBody.messages[0]).toEqual({
+      role: 'system',
+      content: [
+        {
+          type: 'text',
+          text: 'Reusable system prefix',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    });
+  });
+
+  it('keeps text separators when an Anthropic block uses cache control', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+      );
+
+    await handleMessagesRequest(
+      makeNextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        model: 'claude-sonnet-4.6',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Reusable prompt prefix',
+                cache_control: { type: 'ephemeral' },
+              },
+              { type: 'text', text: 'Question' },
+            ],
+          },
+        ],
+      },
+    );
+
+    const upstreamBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown; role: string }> };
+
+    expect(upstreamBody.messages[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Reusable prompt prefix',
+          cache_control: { type: 'ephemeral' },
+        },
+        { type: 'text', text: '\n' },
+        { type: 'text', text: 'Question' },
+      ],
+    });
+  });
+
   it('translates tool_use blocks in non-streaming response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       makeJsonResponse({

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -1265,6 +1265,119 @@ describe('server units', () => {
     });
   });
 
+  it('applies prompt cache control only when it is safe and useful', async () => {
+    const credential = (await listCredentials()).credentials[0];
+    expect(credential).toBeDefined();
+
+    const context = await resolveProxyContextByCredentialFilename(
+      String(credential?.filename),
+    );
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      return Promise.resolve(
+        makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+      );
+    });
+    const longText = 'cached prompt '.repeat(80);
+
+    await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      {
+        messages: [
+          { content: longText, role: 'system' },
+          { content: longText, role: 'user' },
+        ],
+      },
+      context,
+    );
+    await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      {
+        messages: [
+          {
+            content: [
+              {
+                cache_control: { type: 'ephemeral' },
+                text: 'explicit cache marker',
+                type: 'text',
+              },
+            ],
+            role: 'system',
+          },
+          { content: longText, role: 'user' },
+        ],
+      },
+      context,
+    );
+    await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      {
+        messages: [
+          {
+            content: [
+              { text: 'short text', type: 'text' },
+              { text: longText, type: 'text' },
+            ],
+            role: 'user',
+          },
+        ],
+      },
+      context,
+    );
+    await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      { messages: [{ content: 'short reply', role: 'assistant' }] },
+      context,
+    );
+
+    const firstBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown }> };
+    const secondBody = JSON.parse(
+      String((fetchMock.mock.calls[1]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown }> };
+    const thirdBody = JSON.parse(
+      String((fetchMock.mock.calls[2]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown }> };
+    const fourthBody = JSON.parse(
+      String((fetchMock.mock.calls[3]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ content: unknown }> };
+
+    expect(firstBody.messages.map((message) => message.content)).toEqual([
+      [
+        {
+          cache_control: { type: 'ephemeral' },
+          text: longText,
+          type: 'text',
+        },
+      ],
+      [
+        {
+          cache_control: { type: 'ephemeral' },
+          text: longText,
+          type: 'text',
+        },
+      ],
+    ]);
+    expect(secondBody.messages[1]?.content).toBe(longText);
+    expect(thirdBody.messages[0]?.content).toEqual([
+      { text: 'short text', type: 'text' },
+      {
+        cache_control: { type: 'ephemeral' },
+        text: longText,
+        type: 'text',
+      },
+    ]);
+    expect(fourthBody.messages[0]?.content).toBe('short reply');
+  });
+
   it('normalizes developer messages for chat upstream based on position', async () => {
     await addCredential({
       bearer_token: 'token-dev-role',

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -596,6 +596,33 @@ describe('server units', () => {
       model: 'glm-5.1',
       totalTokens: 20,
     });
+
+    await recordUsageEvent({
+      accessKeyId: 'key-1',
+      accessKeyName: 'Team Key',
+      credentialFilename: 'legacy-credential.json',
+      model: 'glm-5.1',
+      route: '/v1/chat/completions',
+      timestamp: '2026-07-11T11:50:00.000Z',
+      usage: {
+        completion_tokens: 4,
+        prompt_tokens: 16,
+        prompt_tokens_details: {
+          cached_tokens: 6,
+          cache_creation_tokens: 4,
+        },
+      },
+    });
+
+    const openAIAnalytics = await getUsageAnalytics({
+      now,
+      range: '24h',
+    });
+    expect(openAIAnalytics.tableRows[0]).toMatchObject({
+      cacheHitTokens: 8,
+      model: 'glm-5.1',
+      totalTokens: 40,
+    });
     expect(analytics.tokenSeries[0]?.points).toHaveLength(24);
     expect(
       analytics.filters.accessKeys.some((item) => item.value === 'key-1'),


### PR DESCRIPTION
### Motivation
- Cache metrics were reporting near-zero cache hits for OpenAI-compatible upstream responses and Anthropic-format cache hints were being dropped during translation.  
- Unit tests could accidentally exercise upstream networking semantics; tests should assert behavior with mocked upstreams only.

### Description
- Parse OpenAI `prompt_tokens_details` fields (`cached_tokens` and `cache_creation_tokens`) into usage aggregation and avoid double-counting those tokens when `prompt_tokens` is present by updating `lib/server/domain/usage.ts`.  
- Preserve Anthropic `cache_control` text blocks when mapping Anthropic `/v1/messages` content into OpenAI-compatible chat messages by extending the Anthropic mapper with structured text support in `lib/server/proxy/anthropic.ts`.  
- Add automatic ephemeral prompt-cache markers for large `system`/last-`user` text blocks when no explicit cache-control exists via `hasPromptCacheControl` / `addPromptCacheControl` / `applyPromptCacheControl` in `lib/server/proxy/codebuddy.ts`.  
- Add unit tests for Anthropic cache-control passthrough and OpenAI `prompt_tokens_details` accounting and update expectations to use mocked `fetch` responses (tests remain fully mocked), plus small formatting/type tweaks to accommodate the changes in tests under `tests/server/anthropic.test.ts` and `tests/server/units.test.ts`.

### Testing
- Ran `bun run lint` and `bun run format:check`, both succeeded.  
- Ran `bun run typecheck`, which succeeded.  
- Ran `bun run test:coverage`, all tests passed (`151` tests) and coverage remained above threshold at `93.83%`.  
- Ran `bun run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5753287dec83259470b447e028c456)