### PR TITLE
fix: align passkey verification and login copy

### DIFF
--- a/app/login/login-client.tsx
+++ b/app/login/login-client.tsx
@@ -89,7 +89,7 @@ const LoginClient = ({
     initialSession.accountConfigured
       ? initialSession.passkeyCount > 0
         ? translations.passwordSignInHint
-        : translations.errorPasswordStatus
+        : ''
       : translations.createPasswordStatus,
   );
 
@@ -289,9 +289,6 @@ const LoginClient = ({
         variant="outlined"
       >
         <Flexbox direction="vertical" gap={8}>
-          <Text as="div" fontSize={13} type="secondary" weight={500}>
-            CodeBuddy2API Admin
-          </Text>
           <Text as="h1" className="login-title" weight={650}>
             {passwordMode === 'setup'
               ? translations.headingSetup
@@ -341,11 +338,6 @@ const LoginClient = ({
               onChange={(event) => {
                 setPassword(event.target.value);
               }}
-              placeholder={
-                passwordMode === 'setup'
-                  ? translations.createPasswordPlaceholder
-                  : translations.passwordLabel
-              }
               type="password"
               value={password}
             />

--- a/lib/server/admin/session.ts
+++ b/lib/server/admin/session.ts
@@ -929,6 +929,7 @@ export const finishAdminPasskeyRegistration = async (
       expectedChallenge,
       expectedOrigin: getWebAuthnOrigin(request),
       expectedRPID: await getWebAuthnRpId(request),
+      requireUserVerification: false,
       response: responseBody as unknown as RegistrationResponseJSON,
     });
   } catch (error) {
@@ -1059,6 +1060,7 @@ export const finishAdminPasskeyAuthentication = async (
       expectedChallenge,
       expectedOrigin: getWebAuthnOrigin(request),
       expectedRPID: await getWebAuthnRpId(request),
+      requireUserVerification: false,
       response: responseBody as unknown as AuthenticationResponseJSON,
     });
   } catch (error) {

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -318,7 +318,7 @@
       "autofillAvailable": "Passkey autofill is available and the page will try it automatically.",
       "autofillUnavailable": "Passkeys are configured, but this browser does not support conditional autofill. Use the passkey button instead.",
       "continueWithPasskey": "Continue with passkey",
-      "continueWithPassword": "Continue with password",
+      "continueWithPassword": "Sign in",
       "createAccountRedirecting": "Admin account created. Redirecting...",
       "createPasswordLabel": "Create admin password",
       "createPasswordPlaceholder": "Choose a strong password",
@@ -330,7 +330,7 @@
       "errorPasskeyFailed": "Passkey sign-in failed. Try again or use your password.",
       "errorPasskeyUnavailable": "Passkey sign-in is unavailable right now.",
       "errorPasswordStatus": "Use your admin password to continue.",
-      "headingLogin": "Sign in to the admin console",
+      "headingLogin": "Sign in to CodeBuddy2API",
       "headingSetup": "Set up the admin account",
       "noPasskeysConfigured": "No passkeys are configured for this admin account yet.",
       "orLabel": "or",
@@ -339,13 +339,13 @@
       "passkeyHintSetup": "and signs you in immediately.",
       "passkeyStatusManual": "Opening the passkey prompt...",
       "passwordAccepted": "Password accepted. Redirecting...",
-      "passwordLabel": "Admin password",
+      "passwordLabel": "Password",
       "passwordSignInHint": "Use your password or a saved passkey to continue.",
       "signInWithPassword": "Creating the admin account...",
       "signingInPassword": "Signing in with password...",
       "title": "Admin sign in",
       "waitingForPasskey": "Waiting for a saved passkey...",
-      "usernameLabel": "Admin username"
+      "usernameLabel": "Username"
     }
   }
 }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -319,7 +319,7 @@
       "autofillAvailable": "対応ブラウザでは passkey 自動入力が利用可能で、このページで自動的に試行されます。",
       "autofillUnavailable": "passkey は設定済みですが、このブラウザは条件付き自動入力をサポートしていません。代わりに passkey ボタンを使用してください。",
       "continueWithPasskey": "passkey で続行",
-      "continueWithPassword": "パスワードで続行",
+      "continueWithPassword": "ログイン",
       "createAccountRedirecting": "管理者アカウントを作成しました。リダイレクトしています...",
       "createPasswordLabel": "管理者パスワードを作成",
       "createPasswordPlaceholder": "強力なパスワードを入力",
@@ -331,7 +331,7 @@
       "errorPasskeyFailed": "passkey サインインに失敗しました。再試行するか、パスワードを使用してください。",
       "errorPasskeyUnavailable": "現在 passkey サインインは利用できません。",
       "errorPasswordStatus": "管理者パスワードを使用して続行してください。",
-      "headingLogin": "管理者コンソールにサインイン",
+      "headingLogin": "CodeBuddy2API にログイン",
       "headingSetup": "管理者アカウントをセットアップ",
       "noPasskeysConfigured": "この管理者アカウントにはまだ passkey が設定されていません。",
       "orLabel": "または",
@@ -340,13 +340,13 @@
       "passkeyHintSetup": "設定成功後は即座にサインインされます。",
       "passkeyStatusManual": "passkey プロンプトを開いています...",
       "passwordAccepted": "パスワードを確認しました。リダイレクトしています...",
-      "passwordLabel": "管理者パスワード",
+      "passwordLabel": "パスワード",
       "passwordSignInHint": "パスワードまたは保存済み passkey を使用して続行してください。",
       "signInWithPassword": "管理者アカウントを作成しています...",
       "signingInPassword": "パスワードでサインインしています...",
       "title": "管理者サインイン",
       "waitingForPasskey": "保存済み passkey を待っています...",
-      "usernameLabel": "管理者ユーザー名"
+      "usernameLabel": "ユーザー名"
     }
   }
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -315,7 +315,7 @@
       "autofillAvailable": "当前浏览器支持 passkey 条件式自动填充，页面会自动尝试登录。",
       "autofillUnavailable": "已配置 passkey，但当前浏览器不支持条件式自动填充，请使用 passkey 按钮登录。",
       "continueWithPasskey": "使用 passkey 继续",
-      "continueWithPassword": "使用密码继续",
+      "continueWithPassword": "登录",
       "createAccountRedirecting": "管理员账户已创建，正在跳转...",
       "createPasswordLabel": "创建管理员密码",
       "createPasswordPlaceholder": "请输入高强度密码",
@@ -327,7 +327,7 @@
       "errorPasskeyFailed": "Passkey 登录失败，请重试或改用密码。",
       "errorPasskeyUnavailable": "当前无法使用 passkey 登录。",
       "errorPasswordStatus": "请输入管理员密码继续。",
-      "headingLogin": "登录管理控制台",
+      "headingLogin": "登录 CodeBuddy2API",
       "headingSetup": "设置管理员账户",
       "noPasskeysConfigured": "当前管理员账户还没有配置 passkey。",
       "orLabel": "或",
@@ -336,13 +336,13 @@
       "passkeyHintSetup": "设置成功后会立即为你登录。",
       "passkeyStatusManual": "正在打开 passkey 验证窗口...",
       "passwordAccepted": "密码验证通过，正在跳转...",
-      "passwordLabel": "管理员密码",
+      "passwordLabel": "密码",
       "passwordSignInHint": "请输入密码或使用已保存的 passkey 继续。",
       "signInWithPassword": "正在创建管理员账户...",
       "signingInPassword": "正在使用密码登录...",
       "title": "管理员登录",
       "waitingForPasskey": "正在等待已保存的 passkey...",
-      "usernameLabel": "管理员用户名"
+      "usernameLabel": "用户名"
     }
   }
 }

--- a/tests/admin/login.test.tsx
+++ b/tests/admin/login.test.tsx
@@ -40,7 +40,7 @@ const loginTranslations: AdminLoginMessages = {
   autofillAvailable: 'Passkey autofill is available.',
   autofillUnavailable: 'Passkey autofill is unavailable.',
   continueWithPasskey: 'Continue with passkey',
-  continueWithPassword: 'Continue with password',
+  continueWithPassword: 'Sign in',
   createAccountRedirecting: 'Admin account created. Redirecting...',
   createPasswordLabel: 'Create admin password',
   createPasswordPlaceholder: 'Choose a strong password',
@@ -53,7 +53,7 @@ const loginTranslations: AdminLoginMessages = {
   errorPasskeyFailed: 'Passkey sign-in failed.',
   errorPasskeyUnavailable: 'Passkey sign-in is unavailable right now.',
   errorPasswordStatus: 'Use your admin password to continue.',
-  headingLogin: 'Sign in to the admin console',
+  headingLogin: 'Sign in to CodeBuddy2API',
   headingSetup: 'Set up the admin account',
   noPasskeysConfigured: 'No passkeys are configured.',
   orLabel: 'or',
@@ -62,12 +62,12 @@ const loginTranslations: AdminLoginMessages = {
   passkeyHintSetup: 'and signs you in immediately.',
   passkeyStatusManual: 'Opening the passkey prompt...',
   passwordAccepted: 'Password accepted. Redirecting...',
-  passwordLabel: 'Admin password',
+  passwordLabel: 'Password',
   passwordSignInHint: 'Use your password or a saved passkey to continue.',
   signInWithPassword: 'Creating the admin account...',
   signingInPassword: 'Signing in with password...',
   title: 'Admin sign in',
-  usernameLabel: 'Admin username',
+  usernameLabel: 'Username',
   waitingForPasskey: 'Waiting for a saved passkey...',
 };
 
@@ -110,7 +110,7 @@ describe('LoginClient', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Admin username'), {
+    fireEvent.change(screen.getByLabelText('Username'), {
       target: { value: 'admin' },
     });
     fireEvent.change(screen.getByLabelText('Create admin password'), {
@@ -160,15 +160,13 @@ describe('LoginClient', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Admin username'), {
+    fireEvent.change(screen.getByLabelText('Username'), {
       target: { value: 'admin' },
     });
-    fireEvent.change(screen.getByLabelText('Admin password'), {
+    fireEvent.change(screen.getByLabelText('Password'), {
       target: { value: 'secret-password' },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with password' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith(

--- a/tests/server/admin-auth-passkeys.test.ts
+++ b/tests/server/admin-auth-passkeys.test.ts
@@ -135,6 +135,9 @@ describe('admin auth passkeys', () => {
       'Primary key',
     );
     expect(registerResponse.status).toBe(200);
+    expect(mockVerifyRegistrationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ requireUserVerification: false }),
+    );
     expect(await adminAuth.listAdminPasskeys()).toEqual([
       expect.objectContaining({
         counter: 1,
@@ -164,6 +167,9 @@ describe('admin auth passkeys', () => {
       },
     );
     expect(authResponse.status).toBe(200);
+    expect(mockVerifyAuthenticationResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ requireUserVerification: false }),
+    );
     expect(getCookieHeader(authResponse)).toContain('Secure');
     expect(await adminAuth.listAdminPasskeys()).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- accept passkeys registered without user verification when the request uses the existing preferred verification policy
- simplify login-page title, labels, password action, and initial hint
- remove the password placeholder and redundant admin subtitle

## Root cause
SimpleWebAuthn verifies user verification by default, while registration options only prefer it. A credential could therefore be saved by the authenticator and then rejected by the server.

## Validation
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage
- bun run build