### PR TITLE
fix: restore "Create API key" button in credentials top-right

### DIFF
--- a/app/credentials/access-key-card.tsx
+++ b/app/credentials/access-key-card.tsx
@@ -14,12 +14,14 @@ interface AccessKeyCardProps {
   accessKey: AccessKeySummary;
   actionId: string | null;
   form: AccessKeyFormState;
+  isCreating?: boolean;
   revealedSecret: RevealedAccessKeySecret | null;
   validCredentials: CredentialSummary[];
-  onDelete: () => void;
-  onEdit: () => void;
+  onCancel?: () => void;
+  onDelete?: () => void;
+  onEdit?: () => void;
   onResetAccessKeyForm: () => void;
-  onRevealSecret: () => void;
+  onRevealSecret?: () => void;
   onSaveAccessKey: () => void;
   onToggleCredentialSelection: (filename: string) => void;
   onUpdateAccessKeyName: (value: string) => void;
@@ -29,8 +31,10 @@ export const AccessKeyCard = ({
   accessKey,
   actionId,
   form,
+  isCreating = false,
   revealedSecret,
   validCredentials,
+  onCancel,
   onDelete,
   onEdit,
   onResetAccessKeyForm,
@@ -42,9 +46,13 @@ export const AccessKeyCard = ({
   const locale = useLocale();
   const text = useTranslations('Admin');
   const common = useTranslations('Admin.common');
-  const isEditing = form.editingId === accessKey.id;
-  const isRevealed = revealedSecret?.id === accessKey.id;
-  const isBusy = actionId === accessKey.id;
+  const isEditing = !isCreating && form.editingId === accessKey.id;
+  const isRevealed = !isCreating && revealedSecret?.id === accessKey.id;
+  const isBusy = actionId === (isCreating ? '__new__' : accessKey.id);
+  const showEditor = isCreating || isEditing;
+  const nameInputId = isCreating
+    ? 'accessKeyName-new'
+    : `accessKeyName-${accessKey.id}`;
 
   return (
     <Block
@@ -54,53 +62,55 @@ export const AccessKeyCard = ({
       padding={24}
       variant="outlined"
     >
-      <div className="access-key-card-header flex items-start justify-between gap-4">
-        <div className="access-key-card-content min-w-0">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="font-semibold text-text-light dark:text-text-dark">
-              {accessKey.name}
+      {!isCreating ? (
+        <div className="access-key-card-header flex items-start justify-between gap-4">
+          <div className="access-key-card-content min-w-0">
+            <div className="flex items-center gap-2 mb-2">
+              <div className="font-semibold text-text-light dark:text-text-dark">
+                {accessKey.name}
+              </div>
+              <Tag color="blue">
+                {text('credentials.accessKeyCount', {
+                  count: accessKey.credentialFilenames.length,
+                })}
+              </Tag>
             </div>
-            <Tag color="blue">
-              {text('credentials.accessKeyCount', {
-                count: accessKey.credentialFilenames.length,
-              })}
-            </Tag>
+            <div className="font-mono text-sm text-secondary break-all">
+              {accessKey.maskedSecret}
+            </div>
+            <div className="flex flex-wrap gap-4 text-sm text-secondary mt-3">
+              <span className="flex items-center gap-1">
+                <CalendarDays aria-hidden="true" size={14} />
+                {text('credentials.accessKeyCreatedAt', {
+                  value: new Date(accessKey.createdAt).toLocaleString(locale),
+                })}
+              </span>
+              <span className="flex items-center gap-1">
+                <Pencil aria-hidden="true" size={14} />
+                {text('credentials.accessKeyUpdatedAt', {
+                  value: new Date(accessKey.updatedAt).toLocaleString(locale),
+                })}
+              </span>
+            </div>
+            <Flexbox gap={8} wrap="wrap">
+              {accessKey.credentialFilenames.map((filename) => (
+                <Tag key={filename}>{filename}</Tag>
+              ))}
+            </Flexbox>
           </div>
-          <div className="font-mono text-sm text-secondary break-all">
-            {accessKey.maskedSecret}
+          <div className="access-key-card-actions flex gap-2 shrink-0">
+            <Button disabled={isBusy} icon={Eye} onClick={onRevealSecret}>
+              {text('credentials.viewKey')}
+            </Button>
+            <Button icon={Pencil} onClick={onEdit} type="primary">
+              {text('credentials.edit')}
+            </Button>
+            <Button danger disabled={isBusy} icon={Trash2} onClick={onDelete}>
+              {text('credentials.delete')}
+            </Button>
           </div>
-          <div className="flex flex-wrap gap-4 text-sm text-secondary mt-3">
-            <span className="flex items-center gap-1">
-              <CalendarDays aria-hidden="true" size={14} />
-              {text('credentials.accessKeyCreatedAt', {
-                value: new Date(accessKey.createdAt).toLocaleString(locale),
-              })}
-            </span>
-            <span className="flex items-center gap-1">
-              <Pencil aria-hidden="true" size={14} />
-              {text('credentials.accessKeyUpdatedAt', {
-                value: new Date(accessKey.updatedAt).toLocaleString(locale),
-              })}
-            </span>
-          </div>
-          <Flexbox gap={8} wrap="wrap">
-            {accessKey.credentialFilenames.map((filename) => (
-              <Tag key={filename}>{filename}</Tag>
-            ))}
-          </Flexbox>
         </div>
-        <div className="access-key-card-actions flex gap-2 shrink-0">
-          <Button disabled={isBusy} icon={Eye} onClick={onRevealSecret}>
-            {text('credentials.viewKey')}
-          </Button>
-          <Button icon={Pencil} onClick={onEdit} type="primary">
-            {text('credentials.edit')}
-          </Button>
-          <Button danger disabled={isBusy} icon={Trash2} onClick={onDelete}>
-            {text('credentials.delete')}
-          </Button>
-        </div>
-      </div>
+      ) : null}
       {isRevealed ? (
         <Flexbox direction="vertical" gap={8}>
           <div className="mb-2 font-medium text-text-light dark:text-text-dark">
@@ -115,10 +125,12 @@ export const AccessKeyCard = ({
           </Block>
         </Flexbox>
       ) : null}
-      {isEditing ? (
+      {showEditor ? (
         <Flexbox direction="vertical" gap={16}>
           <div className="font-medium text-text-light dark:text-text-dark">
-            {text('credentials.accessKeyEdit')}
+            {isCreating
+              ? text('credentials.accessKeyCreateTitle')
+              : text('credentials.accessKeyEdit')}
           </div>
           <div className="text-sm text-secondary mt-2">
             {text('credentials.accessKeyHelp')}
@@ -126,12 +138,12 @@ export const AccessKeyCard = ({
           <div className="mt-4">
             <label
               className="block mb-2 font-medium text-text-light dark:text-text-dark"
-              htmlFor={`accessKeyName-${accessKey.id}`}
+              htmlFor={nameInputId}
             >
               {text('credentials.accessKeyName')}
             </label>
             <Input
-              id={`accessKeyName-${accessKey.id}`}
+              id={nameInputId}
               placeholder={text('credentials.accessKeyExampleName')}
               type="text"
               value={form.name}
@@ -182,7 +194,7 @@ export const AccessKeyCard = ({
             </div>
           </div>
           <div className="mt-4 flex gap-2">
-            <Button icon={X} onClick={onResetAccessKeyForm}>
+            <Button icon={X} onClick={onCancel ?? onResetAccessKeyForm}>
               {common('cancel')}
             </Button>
             <Button

--- a/app/credentials/credentials.tsx
+++ b/app/credentials/credentials.tsx
@@ -14,6 +14,7 @@ import {
   MousePointerClick,
   Pencil,
   Play,
+  Plus,
   RefreshCw,
   Save,
   WandSparkles,
@@ -103,6 +104,7 @@ export interface AccessKeyFormState {
 
 export interface CredentialsState {
   accessKeyActionId: string | null;
+  accessKeyCreating: boolean;
   accessKeyForm: AccessKeyFormState;
   accessKeys: AccessKeySummary[];
   accessKeysLoading: boolean;
@@ -131,6 +133,7 @@ export const authStateAtom = atom<AuthState>(defaultAuthState);
 
 export const defaultCredentialsState: CredentialsState = {
   accessKeyActionId: null,
+  accessKeyCreating: false,
   accessKeyForm: { credentialFilenames: [], editingId: null, name: '' },
   accessKeys: [],
   accessKeysLoading: true,
@@ -174,6 +177,7 @@ export const createCredentialsState = (
 export interface CredentialsTabController {
   auth: AuthState;
   credentials: CredentialsState;
+  onAddAccessKey: () => void;
   onAddCredential: () => void;
   onAuthAction: () => void;
   onCallbackUrlChange: (value: string) => void;
@@ -219,6 +223,7 @@ const Credentials = () => {
   const {
     auth,
     credentials,
+    onAddAccessKey,
     onAddCredential,
     onAuthAction,
     onCallbackUrlChange,
@@ -459,10 +464,37 @@ const Credentials = () => {
             icon={KeyRound}
             title={credentialsText('credentials.accessKeyLabel')}
           />
-          <Button icon={RefreshCw} onClick={onRefreshAccessKeys}>
-            {common('refresh')}
-          </Button>
+          <div className="flex gap-2">
+            <Button icon={Plus} onClick={onAddAccessKey} type="primary">
+              {credentialsText('credentials.accessKeyCreate')}
+            </Button>
+            <Button icon={RefreshCw} onClick={onRefreshAccessKeys}>
+              {common('refresh')}
+            </Button>
+          </div>
         </div>
+        {credentials.accessKeyCreating ? (
+          <AccessKeyCard
+            accessKey={{
+              createdAt: new Date().toISOString(),
+              credentialFilenames: [],
+              id: '__new__',
+              maskedSecret: '',
+              name: credentialsText('credentials.accessKeyCreateTitle'),
+              updatedAt: new Date().toISOString(),
+            }}
+            actionId={credentials.accessKeyActionId}
+            form={credentials.accessKeyForm}
+            isCreating
+            revealedSecret={credentials.revealedSecret}
+            validCredentials={validCredentials}
+            onCancel={onResetAccessKeyForm}
+            onResetAccessKeyForm={onResetAccessKeyForm}
+            onSaveAccessKey={onSaveAccessKey}
+            onToggleCredentialSelection={onToggleCredentialSelection}
+            onUpdateAccessKeyName={onUpdateAccessKeyName}
+          />
+        ) : null}
         <div id="accessKeysList">
           {credentials.accessKeysLoading ? (
             <div className="text-center py-8 text-secondary">

--- a/app/page-shell.tsx
+++ b/app/page-shell.tsx
@@ -1033,6 +1033,7 @@ const AdminPageLayoutContent = ({
     setCredentials((current) => ({
       ...current,
       accessKeyActionId: null,
+      accessKeyCreating: false,
       accessKeyForm: {
         credentialFilenames: [],
         editingId: null,
@@ -1600,6 +1601,17 @@ const AdminPageLayoutContent = ({
               value={{
                 auth,
                 credentials,
+                onAddAccessKey: () => {
+                  setCredentials((current) => ({
+                    ...current,
+                    accessKeyCreating: true,
+                    accessKeyForm: {
+                      credentialFilenames: [],
+                      editingId: null,
+                      name: '',
+                    },
+                  }));
+                },
                 onAddCredential: () => {
                   void addCredential();
                 },
@@ -1673,6 +1685,7 @@ const AdminPageLayoutContent = ({
                 onEditAccessKey: (accessKey) => {
                   setCredentials((current) => ({
                     ...current,
+                    accessKeyCreating: false,
                     accessKeyForm: {
                       credentialFilenames: accessKey.credentialFilenames.filter(
                         (filename) =>
@@ -1769,6 +1782,7 @@ const AdminPageLayoutContent = ({
                 onResetAccessKeyForm: () => {
                   setCredentials((current) => ({
                     ...current,
+                    accessKeyCreating: false,
                     accessKeyForm: {
                       credentialFilenames: [],
                       editingId: null,

--- a/app/page-shell.tsx
+++ b/app/page-shell.tsx
@@ -529,7 +529,7 @@ const AdminPageLayoutContent = ({
 
     setCredentials((current) => ({
       ...current,
-      accessKeyActionId: null,
+      accessKeyActionId: current.accessKeyActionId ?? null,
       accessKeys: result.data?.access_keys ?? [],
       accessKeysLoading: false,
     }));

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -73,6 +73,8 @@
     },
     "credentials": {
       "accessKeyCount": "{count} credentials",
+      "accessKeyCreate": "Create API key",
+      "accessKeyCreateTitle": "Create API key",
       "accessKeyCreatedAt": "Created {value}",
       "accessKeyCurrent": "Current API key",
       "accessKeyEdit": "Edit API key",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -73,6 +73,8 @@
     },
     "credentials": {
       "accessKeyCount": "{count} 件の認証情報",
+      "accessKeyCreate": "API key を作成",
+      "accessKeyCreateTitle": "API key を作成",
       "accessKeyCreatedAt": "作成: {value}",
       "accessKeyCurrent": "現在の API key",
       "accessKeyEdit": "API key を編集",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -73,6 +73,8 @@
     },
     "credentials": {
       "accessKeyCount": "{count} 个凭证",
+      "accessKeyCreate": "创建 API Key",
+      "accessKeyCreateTitle": "创建 API Key",
       "accessKeyCreatedAt": "创建于 {value}",
       "accessKeyCurrent": "当前 API Key",
       "accessKeyEdit": "编辑 API Key",


### PR DESCRIPTION
## 问题

在之前的 admin UI 重构中，API Key 管理区块丢失了右上角的「创建 API Key」入口。重构后只剩「刷新」按钮，用户只能编辑/删除已有 key，**无法新建**，表现为"有 apikey 时右上角没有添加 apikey 按钮"。

## 修复

- `app/credentials/credentials.tsx`：`CredentialsState` 增加 `accessKeyCreating` 字段；控制器接口增加 `onAddAccessKey`；API Key 区块右上角重新加回「创建 API Key」按钮（`Plus` 图标，`type="primary"`），点击后内联渲染新建表单。
- `app/credentials/access-key-card.tsx`：新增 `isCreating` / `onCancel` props；新建模式下隐藏卡片展示头部，改为可填写的创建表单（名称 + 绑定凭证 + 保存/取消）。
- `app/page-shell.tsx`：新增 `onAddAccessKey` 回调；`onResetAccessKeyForm` 与保存成功/失败都清理 `accessKeyCreating`；`onEditAccessKey` 进入编辑时关闭新建态，避免冲突。
- `messages/*.json`：新增 `accessKeyCreate`、`accessKeyCreateTitle` 翻译（中/英/日）。

## 验证

- `tsc --noEmit` 通过
- ESLint 无警告
- 154 个测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)