### PR TITLE
fix: allow stale admin session cookies

### DIFF
--- a/lib/server/admin/session.ts
+++ b/lib/server/admin/session.ts
@@ -628,6 +628,10 @@ export const updateAdminSessionUsagePreferences = async (
   const tokenHash = hashSessionToken(token);
 
   return mutateAdminAuthState((state) => {
+    if (!state.enabled) {
+      return normalizedPreferences;
+    }
+
     const session = state.sessions.find(
       (entry) => entry.tokenHash === tokenHash,
     );

--- a/tests/server/admin-auth-storage.test.ts
+++ b/tests/server/admin-auth-storage.test.ts
@@ -236,10 +236,11 @@ describe('admin auth and storage', () => {
         .usagePreferences,
     ).toBeNull();
 
-    await setupAdminPassword(
+    const setupResponse = await setupAdminPassword(
       makeRequest('/admin-api/auth/setup'),
       'correct horse battery staple',
     );
+    const sessionCookie = getCookieHeader(setupResponse);
 
     await expect(
       updateAdminSessionUsagePreferences(
@@ -255,6 +256,20 @@ describe('admin auth and storage', () => {
         preferences,
       ),
     ).resolves.toBeNull();
+
+    expect(
+      (
+        await disableAdminAuthentication(
+          makeRequest('/admin-api/auth/password', { cookie: sessionCookie }),
+        )
+      ).status,
+    ).toBe(200);
+    await expect(
+      updateAdminSessionUsagePreferences(
+        makeRequest('/admin-api/usage', { cookie: sessionCookie }),
+        preferences,
+      ),
+    ).resolves.toEqual(normalizedPreferences);
     await expect(
       updateAdminSessionUsagePreferences(makeRequest('/admin-api/usage'), null),
     ).resolves.toBeNull();


### PR DESCRIPTION
## Summary

- allow Usage filters to update when admin authentication is disabled and a stale `codebuddy_admin_session` cookie is present
- retain rejection of unknown session tokens while admin authentication is enabled
- add regression coverage for disabling authentication after an authenticated session exists

## Root cause

`PATCH /admin-api/usage` correctly bypasses the admin-auth guard when authentication is disabled, but its preference persistence path still treated a supplied stale cookie as an invalid authenticated session and returned 401.

## Validation

- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:coverage`
- `bun run test:ci` (CI artifacts will be generated by GitHub Actions)
- `bun run build`
