### PR TITLE
feat: manage credential model availability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ CODEBUDDY_LOG_LEVEL=INFO
 # Optional upstream overrides
 # CODEBUDDY_API_ENDPOINT=https://copilot.tencent.com
 # CODEBUDDY_INTERNET_ENVIRONMENT=ioa
-# CODEBUDDY_MODELS=glm-5.1,glm-5.0,glm-5.0-turbo
+
+# Models are discovered from each saved credential. No model-list setting is needed.
 
 # Optional file-backend data directory. Default: .codebuddy_data
 # CODEBUDDY_STORAGE_FILE_DIR=.codebuddy_data

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Current persisted runtime settings:
 - `CODEBUDDY_AUTH_MODE`
 - `CODEBUDDY_INTERNET_ENVIRONMENT`
 - `CODEBUDDY_LOG_LEVEL`
-- `CODEBUDDY_MODELS`
+
+Models are discovered from CodeBuddy for each active credential. The credentials page shows one row per credential with its supported models and a refresh action. `/v1/models` only merges models from credentials bound to the requesting API key.
 
 ## Logging
 

--- a/app/admin-api/credentials/models/route.ts
+++ b/app/admin-api/credentials/models/route.ts
@@ -1,0 +1,98 @@
+import { getAdminSessionErrorResponse } from '@/lib/server/admin/session';
+import {
+  findEligibleCredentialRecordByFilename,
+  getCredentialSupportedModels,
+  listEligibleCredentialRecords,
+  updateCredentialSupportedModels,
+} from '@/lib/server/domain/credentials';
+import { getModelsByCredential } from '@/lib/server/proxy/codebuddy';
+import { getJsonBody } from '@/lib/server/shared/http';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const toResponse = async (filenames?: string[]): Promise<Response> => {
+  const credentials = await listEligibleCredentialRecords(filenames);
+  const models = Object.fromEntries(
+    credentials.map((credential) => [
+      credential.filename,
+      {
+        error: null,
+        models: getCredentialSupportedModels(credential.data).map((id) => ({
+          id,
+        })),
+      },
+    ]),
+  );
+
+  return Response.json({ models });
+};
+
+export const GET = async (request: Request): Promise<Response> => {
+  const authError = await getAdminSessionErrorResponse(request);
+
+  if (authError) return authError;
+
+  return toResponse();
+};
+
+export const POST = async (request: Request): Promise<Response> => {
+  const authError = await getAdminSessionErrorResponse(request);
+
+  if (authError) return authError;
+
+  const body = await getJsonBody<{ filename?: unknown }>(request);
+  const filename =
+    typeof body.filename === 'string' ? body.filename.trim() : '';
+
+  if (!filename || !(await findEligibleCredentialRecordByFilename(filename))) {
+    return Response.json(
+      { error: { message: 'Credential is unavailable' } },
+      { status: 404 },
+    );
+  }
+
+  const models = await getModelsByCredential(
+    await listEligibleCredentialRecords([filename]),
+  );
+  const value = models[filename];
+
+  if (value && !value.error) {
+    await updateCredentialSupportedModels(
+      filename,
+      value.models.map((model) => model.id),
+    );
+  }
+
+  return Response.json({ models });
+};
+
+export const PUT = async (request: Request): Promise<Response> => {
+  const authError = await getAdminSessionErrorResponse(request);
+
+  if (authError) return authError;
+
+  const body = await getJsonBody<{ filename?: unknown; models?: unknown }>(
+    request,
+  );
+  const filename =
+    typeof body.filename === 'string' ? body.filename.trim() : '';
+
+  if (!filename || !(await findEligibleCredentialRecordByFilename(filename))) {
+    return Response.json(
+      { error: { message: 'Credential is unavailable' } },
+      { status: 404 },
+    );
+  }
+
+  const models =
+    typeof body.models === 'string'
+      ? body.models
+          .split(/[\n,]/)
+          .map((model) => model.trim())
+          .filter(Boolean)
+      : [];
+  await updateCredentialSupportedModels(filename, models);
+
+  return toResponse([filename]);
+};

--- a/app/api-test/api-test.tsx
+++ b/app/api-test/api-test.tsx
@@ -8,39 +8,6 @@ import { useTranslations } from 'next-intl';
 import { createContext, useContext } from 'react';
 import type { AdminConsoleInitialData } from '@/app/page-data';
 
-const defaultModels = [
-  'glm-5.1',
-  'glm-5.0',
-  'glm-5.0-turbo',
-  'glm-5v-turbo',
-  'glm-4.7',
-  'minimax-m3-play',
-  'minimax-m2.7',
-  'minimax-m2.5',
-  'kimi-k2.6',
-  'kimi-k2.5',
-  'hy3-preview-agent',
-  'deepseek-v4-pro',
-  'deepseek-v4-flash',
-  'deepseek-v3-2-volc',
-  'glm-5.1-ioa',
-  'glm-5.0-ioa',
-  'glm-5.0-turbo-ioa',
-  'glm-5v-turbo-ioa',
-  'glm-4.7-ioa',
-  'minimax-m3-ioa',
-  'minimax-m2.7-ioa',
-  'minimax-m2.5-ioa',
-  'kimi-k2.6-ioa',
-  'kimi-k2.5-ioa',
-  'hy3-preview-agent-ioa',
-  'deepseek-v4-pro-ioa',
-  'deepseek-v4-flash-ioa',
-  'deepseek-v3-2-volc-ioa',
-] as const;
-
-const followCurrentCredentialValue = '__follow_current_rotation__';
-
 export interface ApiTestController {
   apiTest: {
     credentialFilename: string;
@@ -99,10 +66,11 @@ export const createApiTestState = (
     credentialFilename:
       currentCredential?.filename ?? validCredentials[0]?.filename ?? '',
     model:
-      initialData.modelSettings
-        .split(',')
-        .map((model) => model.trim())
-        .find(Boolean) ?? '',
+      initialData.credentialModels[
+        currentCredential?.filename ?? validCredentials[0]?.filename ?? ''
+      ]?.[0] ??
+      initialData.models[0] ??
+      '',
   };
 };
 
@@ -122,7 +90,7 @@ const useApiTest = (): ApiTestController => {
 const ApiTest = () => {
   const context = useApiTest();
   const apiTestText = useTranslations('Admin.apiTest');
-  const models = context.models.length ? context.models : [...defaultModels];
+  const models = context.models;
   const model = models.includes(context.apiTest.model)
     ? context.apiTest.model
     : (models[0] ?? '');
@@ -144,23 +112,13 @@ const ApiTest = () => {
           <Select
             className="w-full"
             id="testCredential"
-            options={[
-              {
-                label: apiTestText('followCurrent'),
-                value: followCurrentCredentialValue,
-              },
-              ...context.credentialOptions.map((credential) => ({
-                label: `${credential.filename} · ${credential.email || credential.user_id}`,
-                value: credential.filename,
-              })),
-            ]}
-            value={
-              context.apiTest.credentialFilename || followCurrentCredentialValue
-            }
+            options={context.credentialOptions.map((credential) => ({
+              label: `${credential.filename} · ${credential.email || credential.user_id}`,
+              value: credential.filename,
+            }))}
+            value={context.apiTest.credentialFilename}
             onChange={(value) => {
-              context.onCredentialChange(
-                value === followCurrentCredentialValue ? '' : String(value),
-              );
+              context.onCredentialChange(String(value));
             }}
           />
         </div>

--- a/app/credentials/access-key-card.tsx
+++ b/app/credentials/access-key-card.tsx
@@ -98,7 +98,9 @@ export const AccessKeyCard = ({
               wrap="wrap"
             >
               {accessKey.credentialFilenames.map((filename) => (
-                <Tag key={filename}>{filename}</Tag>
+                <Tag className="access-key-credential-tag" key={filename}>
+                  {filename}
+                </Tag>
               ))}
             </Flexbox>
           </div>

--- a/app/credentials/credentials.tsx
+++ b/app/credentials/credentials.tsx
@@ -114,6 +114,8 @@ export interface CredentialsState {
   form: CredentialFormState;
   items: CredentialSummary[];
   loading: boolean;
+  modelRows: Record<string, { error: string | null; models: string[] }>;
+  modelsLoading: boolean;
   revealedSecret: RevealedAccessKeySecret | null;
 }
 
@@ -149,6 +151,8 @@ export const defaultCredentialsState: CredentialsState = {
   },
   items: [],
   loading: true,
+  modelRows: {},
+  modelsLoading: false,
   revealedSecret: null,
 };
 

--- a/app/debug/debug.tsx
+++ b/app/debug/debug.tsx
@@ -1257,11 +1257,11 @@ const Debug = () => {
                             value={
                               hasDuration(item.elapsedMs) &&
                               item.elapsedMs > 0 &&
-                              item.usage?.totalTokens
-                                ? Math.round(
-                                    (item.usage.totalTokens * 1_000) /
+                              item.usage?.outputTokens
+                                ? `${Math.round(
+                                    (item.usage.outputTokens * 1_000) /
                                       item.elapsedMs,
-                                  )
+                                  )} t/s`
                                 : null
                             }
                           />

--- a/app/globals.scss
+++ b/app/globals.scss
@@ -144,12 +144,15 @@ textarea {
   --header-height: 56px;
 
   position: relative !important;
+  container-type: inline-size;
   display: flex;
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid var(--border-color) !important;
   border-radius: 0 !important;
   height: var(--header-height) !important;
+  max-width: 100%;
+  min-width: 0;
   padding: 0 12px 0 24px !important;
   background-color: transparent !important;
   background-image: radial-gradient(
@@ -194,6 +197,10 @@ textarea {
   min-width: 0;
 }
 
+.admin-header-navigation-compact {
+  display: none;
+}
+
 .admin-header-tab {
   background: transparent !important;
   border-color: transparent !important;
@@ -202,16 +209,6 @@ textarea {
 
 .admin-header-tab[data-active] {
   background: var(--lobe-color-fill-secondary) !important;
-}
-
-.admin-header-more-wrap {
-  display: none;
-}
-
-.admin-header-more {
-  background: transparent !important;
-  border-color: transparent !important;
-  box-shadow: none !important;
 }
 
 .admin-header-select {
@@ -233,6 +230,32 @@ textarea {
   display: none;
 }
 
+@container (max-width: 1280px) {
+  .admin-header-navigation-full {
+    display: none;
+  }
+
+  .admin-header-navigation-compact {
+    display: flex;
+  }
+}
+
+@container (max-width: 1120px) {
+  .admin-header-navigation,
+  .admin-header-controls {
+    display: none;
+  }
+
+  .admin-header-brand {
+    flex: 1 1 auto;
+  }
+
+  .admin-header-mobile-menu {
+    display: block;
+    flex: 0 0 auto;
+  }
+}
+
 .console-logout {
   box-shadow: none !important;
 }
@@ -241,16 +264,6 @@ textarea {
   width: min(1440px, 100%);
   margin: 0 auto;
   padding: 24px 32px 48px;
-}
-
-@media (max-width: 1180px) {
-  .admin-header-tab:nth-of-type(n + 4) {
-    display: none;
-  }
-
-  .admin-header-more-wrap {
-    display: block;
-  }
 }
 
 .usage-auto-refresh-control {
@@ -415,7 +428,20 @@ textarea {
 }
 
 #credentials .access-key-credential-tags {
+  max-width: 100%;
+  min-width: 0;
   row-gap: 12px;
+}
+
+#credentials .access-key-credential-tag.ant-tag {
+  width: fit-content;
+  max-width: 100%;
+  height: auto;
+  justify-content: flex-start;
+  overflow-wrap: anywhere;
+  padding: 3px 7px;
+  white-space: normal;
+  word-break: break-all;
 }
 
 #debug .debug-tool-list {
@@ -695,6 +721,24 @@ textarea {
   min-width: 0;
 }
 
+.credential-models-table,
+.credential-models-table .ant-table-wrapper,
+.credential-models-table .ant-table,
+.credential-models-table .ant-table-container,
+.credential-models-table .ant-table-content {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.credential-models-table .ant-table-content {
+  overscroll-behavior-x: contain;
+}
+
+.credential-models-input {
+  max-width: 100%;
+  width: min(360px, calc(100vw - 112px));
+}
+
 @media (max-width: 960px) {
   .dashboard-metric-grid {
     grid-template-columns: 1fr;
@@ -702,34 +746,6 @@ textarea {
 }
 
 @media (max-width: 640px) {
-  .admin-header {
-    display: flex !important;
-    height: 56px;
-    min-height: 56px;
-    padding: 0 12px !important;
-  }
-
-  .admin-header-brand {
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .admin-header-controls {
-    display: none !important;
-  }
-
-  .admin-header-navigation {
-    display: none;
-  }
-
-  .admin-header-mobile-menu {
-    display: block;
-    flex: 0 0 auto;
-  }
-
   .console-main {
     padding: 20px 0 32px;
   }

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -3,7 +3,7 @@
 import { Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { DropdownMenu, Select } from '@lobehub/ui/base-ui';
-import { Ellipsis, Languages, Menu, SunMoon } from 'lucide-react';
+import { Languages, Menu, SunMoon } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import type { ReactNode } from 'react';
@@ -57,50 +57,49 @@ export const AdminHeader = ({
     light: translations('themeLight'),
     system: translations('themeSystem'),
   };
-
   return (
     <header className={`admin-header ${className}`}>
       <Text as="div" className="admin-header-brand" strong>
         {brand ?? translations('brand')}
       </Text>
       {navigationItems?.length ? (
-        <nav
-          aria-label={translations('tabsLabel')}
-          className="admin-header-navigation"
-        >
-          {navigationItems.map(({ icon: Icon, key, label, onClick }) => (
-            <Button
-              className="admin-header-tab"
-              data-active={key === activeNavigationKey ? true : undefined}
-              data-nav-key={key}
-              htmlType="button"
-              icon={Icon}
-              key={key}
-              onClick={onClick}
-            >
-              {label}
-            </Button>
-          ))}
-          <div className="admin-header-more-wrap">
-            <DropdownMenu
-              items={navigationItems.map(({ icon, key, label, onClick }) => ({
-                icon,
-                key,
-                label,
-                onClick,
-              }))}
-              nativeButton
-              placement="bottom"
-            >
+        <>
+          <nav
+            aria-label={translations('tabsLabel')}
+            className="admin-header-navigation admin-header-navigation-full"
+          >
+            {navigationItems.map(({ icon: Icon, key, label, onClick }) => (
               <Button
-                aria-label={translations('tabsLabel')}
-                className="admin-header-more"
+                className="admin-header-tab"
+                data-active={key === activeNavigationKey ? true : undefined}
+                data-nav-key={key}
                 htmlType="button"
-                icon={Ellipsis}
-              />
-            </DropdownMenu>
-          </div>
-        </nav>
+                icon={Icon}
+                key={key}
+                onClick={onClick}
+              >
+                {label}
+              </Button>
+            ))}
+          </nav>
+          <nav
+            aria-label={translations('tabsLabel')}
+            className="admin-header-navigation admin-header-navigation-compact"
+          >
+            {navigationItems.map(({ key, label, onClick }) => (
+              <Button
+                className="admin-header-tab"
+                data-active={key === activeNavigationKey ? true : undefined}
+                data-nav-key={key}
+                htmlType="button"
+                key={key}
+                onClick={onClick}
+              >
+                {label}
+              </Button>
+            ))}
+          </nav>
+        </>
       ) : null}
       <Flexbox
         align="center"

--- a/app/lobe-ui-provider.tsx
+++ b/app/lobe-ui-provider.tsx
@@ -21,6 +21,11 @@ const LobeUiProvider = ({ children, initialTheme }: LobeUiProviderProps) => {
   );
 
   useEffect(() => {
+    const syncFromDocument = () => {
+      setAppearance(
+        document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+      );
+    };
     const syncAppearance = (event: Event) => {
       const nextAppearance = (event as CustomEvent<'dark' | 'light'>).detail;
 
@@ -29,10 +34,17 @@ const LobeUiProvider = ({ children, initialTheme }: LobeUiProviderProps) => {
       }
     };
 
+    syncFromDocument();
     window.addEventListener(themeChangeEventName, syncAppearance);
+    const observer = new MutationObserver(syncFromDocument);
+    observer.observe(document.documentElement, {
+      attributeFilter: ['class'],
+      attributes: true,
+    });
 
     return () => {
       window.removeEventListener(themeChangeEventName, syncAppearance);
+      observer.disconnect();
     };
   }, []);
 

--- a/app/page-data.ts
+++ b/app/page-data.ts
@@ -36,9 +36,10 @@ export interface CredentialsTabInitialData {
 }
 
 export interface ApiTestInitialData {
+  credentialModels: Record<string, string[]>;
   credentials: CredentialSummary[];
   currentCredential: CurrentCredentialInfo;
-  modelSettings: string;
+  models: string[];
   tab: 'api-test';
 }
 

--- a/app/page-loader.ts
+++ b/app/page-loader.ts
@@ -16,8 +16,13 @@ import { listAccessKeys } from '@/lib/server/domain/access-keys';
 import { getActiveConfig, getSettingLabels } from '@/lib/server/domain/config';
 import {
   getCurrentCredentialInfo,
+  listEligibleCredentialRecords,
   listCredentials,
 } from '@/lib/server/domain/credentials';
+import {
+  getModelsByCredential,
+  getModelsForCredentials,
+} from '@/lib/server/proxy/codebuddy';
 import { getDebugSettings, listDebugLogs } from '@/lib/server/domain/debug';
 import { getUsageAnalytics } from '@/lib/server/domain/usage';
 import type { AppLocale } from '@/lib/i18n/routing';
@@ -139,17 +144,26 @@ export const getInitialData = async ({
       };
     }
     case 'api-test': {
-      const [credentials, currentCredential, config] = await Promise.all([
-        listCredentials(),
-        getCurrentCredentialInfo(),
-        getActiveConfig(),
-      ]);
+      const eligibleCredentials = await listEligibleCredentialRecords();
+      const [credentials, currentCredential, models, credentialModels] =
+        await Promise.all([
+          listCredentials(),
+          getCurrentCredentialInfo(),
+          getModelsForCredentials(eligibleCredentials),
+          getModelsByCredential(eligibleCredentials),
+        ]);
 
       return {
+        credentialModels: Object.fromEntries(
+          Object.entries(credentialModels).map(([filename, value]) => [
+            filename,
+            value.models.map((model) => model.id),
+          ]),
+        ),
         credentials: credentials.credentials as unknown as CredentialSummary[],
         currentCredential:
           currentCredential as unknown as CurrentCredentialInfo,
-        modelSettings: config.CODEBUDDY_MODELS,
+        models: models.map((model) => model.id),
         tab,
       };
     }

--- a/app/page-shell.tsx
+++ b/app/page-shell.tsx
@@ -86,6 +86,13 @@ interface CredentialsResponse {
   credentials?: CredentialSummary[];
 }
 
+interface CredentialModelsResponse {
+  models?: Record<
+    string,
+    { error?: string | null; models?: Array<{ id?: string }> }
+  >;
+}
+
 interface AccessKeysResponse {
   access_keys?: AccessKeySummary[];
 }
@@ -234,13 +241,6 @@ const buildApiEndpoint = () => {
   }
 
   return `${window.location.origin}/v1`;
-};
-
-const getConfiguredModels = (rawValue: string | number | null | undefined) => {
-  return String(rawValue ?? '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
 };
 
 const formatResult = (payload: unknown) => {
@@ -507,6 +507,55 @@ const AdminPageLayoutContent = ({
     }));
   }, [setCredentials]);
 
+  const refreshCredentialModels = useCallback(
+    async (filename?: string) => {
+      setCredentials((current) => ({ ...current, modelsLoading: true }));
+      const result = await requestJson<CredentialModelsResponse>(
+        '/admin-api/credentials/models',
+        filename
+          ? {
+              body: JSON.stringify({ filename }),
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST',
+            }
+          : undefined,
+      );
+      const modelRows = Object.fromEntries(
+        Object.entries(result.data?.models ?? {}).map(([key, value]) => [
+          key,
+          {
+            error: value.error ?? null,
+            models: (value.models ?? [])
+              .map((model) => model.id)
+              .filter((model): model is string => Boolean(model)),
+          },
+        ]),
+      );
+
+      setCredentials((current) => ({
+        ...current,
+        modelRows: filename
+          ? { ...current.modelRows, ...modelRows }
+          : modelRows,
+        modelsLoading: false,
+      }));
+      setApiTest((current) => {
+        const selectedFilename = filename ?? current.credentialFilename;
+        const models = modelRows[selectedFilename]?.models;
+
+        if (!models) return current;
+
+        return {
+          ...current,
+          model: models.includes(current.model)
+            ? current.model
+            : (models[0] ?? ''),
+        };
+      });
+    },
+    [setApiTest, setCredentials],
+  );
+
   const refreshCredentialList = useCallback(async () => {
     setCredentials((current) => ({
       ...current,
@@ -571,21 +620,7 @@ const AdminPageLayoutContent = ({
       loading: false,
       values: nextValues,
     }));
-
-    setApiTest((current) => {
-      if (current.model.trim()) {
-        return current;
-      }
-
-      const configuredModels = getConfiguredModels(nextValues.CODEBUDDY_MODELS);
-
-      return {
-        ...current,
-        model: configuredModels[0] ?? current.model,
-        result: current.result || consoleMessages.requestIdle,
-      };
-    });
-  }, [consoleMessages.requestIdle, setApiTest, setSettings]);
+  }, [setSettings]);
 
   const loadDebug = useCallback(
     async ({
@@ -790,7 +825,8 @@ const AdminPageLayoutContent = ({
 
   const refreshAdminData = useCallback(async () => {
     await Promise.all([loadDashboard(), loadCredentials()]);
-  }, [loadCredentials, loadDashboard]);
+    await refreshCredentialModels();
+  }, [loadCredentials, loadDashboard, refreshCredentialModels]);
 
   const clearUsageHistory = async () => {
     setUsage((current) => ({
@@ -1008,6 +1044,9 @@ const AdminPageLayoutContent = ({
         name: result.data.filename ?? 'unknown',
       }),
     );
+    if (!isEditing && result.data.filename) {
+      await refreshCredentialModels(result.data.filename);
+    }
     await refreshAdminData();
   };
 
@@ -1239,10 +1278,7 @@ const AdminPageLayoutContent = ({
             role: 'user',
           },
         ],
-        model:
-          apiTest.model ||
-          getConfiguredModels(settings.values.CODEBUDDY_MODELS)[0] ||
-          'glm-5.1',
+        model: apiTest.model,
         stream: apiTest.stream,
       }),
       headers: {
@@ -1372,24 +1408,6 @@ const AdminPageLayoutContent = ({
       saving: false,
       values: result.data?.settings ?? current.values,
     }));
-    setApiTest((current) => {
-      const configuredModels = getConfiguredModels(
-        result.data?.settings?.CODEBUDDY_MODELS,
-      );
-      const nextModel = configuredModels[0] ?? current.model;
-
-      if (
-        current.model.trim() &&
-        configuredModels.includes(current.model.trim())
-      ) {
-        return current;
-      }
-
-      return {
-        ...current,
-        model: nextModel,
-      };
-    });
     showNotification(
       'success',
       result.data?.message ?? consoleMessages.settingsSaved,
@@ -1927,14 +1945,24 @@ const AdminPageLayoutContent = ({
                     ? initialData.credentials.filter((item) => !item.is_expired)
                     : credentials.items.filter((item) => !item.is_expired),
                 models:
-                  initialData?.tab === 'api-test'
-                    ? getConfiguredModels(initialData.modelSettings)
-                    : getConfiguredModels(settings.values.CODEBUDDY_MODELS),
+                  credentials.modelRows[apiTest.credentialFilename]?.models ??
+                  (initialData?.tab === 'api-test'
+                    ? (initialData.credentialModels[
+                        apiTest.credentialFilename
+                      ] ?? initialData.models)
+                    : []),
                 onCredentialChange: (value) => {
+                  const models =
+                    credentials.modelRows[value]?.models ??
+                    (initialData?.tab === 'api-test'
+                      ? (initialData.credentialModels[value] ?? [])
+                      : []);
                   setApiTest((current) => ({
                     ...current,
                     credentialFilename: value,
+                    model: models[0] ?? '',
                   }));
+                  void refreshCredentialModels(value);
                 },
                 onMessageChange: (value) => {
                   setApiTest((current) => ({ ...current, message: value }));

--- a/app/settings/settings.tsx
+++ b/app/settings/settings.tsx
@@ -2,10 +2,19 @@
 
 import { Block, Flexbox, Input, TextArea } from '@lobehub/ui';
 import { Button, Select } from '@lobehub/ui/base-ui';
+import { Table } from 'antd';
+import type { TableColumnsType } from 'antd';
 import { atom } from 'jotai';
-import { LoaderCircle, Save, Server } from 'lucide-react';
+import {
+  Layers3,
+  LoaderCircle,
+  RefreshCw,
+  Save,
+  Server,
+  Trash2,
+} from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 
 import Security from './security';
 
@@ -110,13 +119,6 @@ const SettingField = ({
           options={selectOptions}
           value={value}
         />
-      ) : settingKey === 'CODEBUDDY_MODELS' ? (
-        <TextArea
-          id={settingKey}
-          onChange={(event) => onChange(event.target.value)}
-          rows={6}
-          value={value}
-        />
       ) : (
         <Input
           id={settingKey}
@@ -130,9 +132,250 @@ const SettingField = ({
   );
 };
 
+interface CredentialModelResponse {
+  models?: Record<
+    string,
+    { error?: string | null; models?: Array<{ id?: string }> }
+  >;
+}
+
+interface CredentialModelRow {
+  error: string | null;
+  filename: string;
+  models: string[];
+  modelsInput: string;
+}
+
+const toCredentialModelRows = (
+  payload: CredentialModelResponse,
+): CredentialModelRow[] => {
+  return Object.entries(payload.models ?? {}).map(([filename, value]) => ({
+    error: value.error ?? null,
+    filename,
+    models: (value.models ?? [])
+      .map((model) => model.id)
+      .filter((model): model is string => Boolean(model)),
+    modelsInput: (value.models ?? [])
+      .map((model) => model.id)
+      .filter((model): model is string => Boolean(model))
+      .join(', '),
+  }));
+};
+
+const parseSupportedModels = (value: string): string[] => {
+  return value
+    .split(/[\n,]/)
+    .map((model) => model.trim())
+    .filter(Boolean);
+};
+
+const CredentialModels = () => {
+  const common = useTranslations('Admin.common');
+  const credentialsText = useTranslations('Admin.credentials');
+  const [loading, setLoading] = useState(true);
+  const [refreshingFilename, setRefreshingFilename] = useState<string | null>(
+    null,
+  );
+  const [savingFilename, setSavingFilename] = useState<string | null>(null);
+  const [rows, setRows] = useState<CredentialModelRow[]>([]);
+  const saveTimersRef = useRef(new Map<string, number>());
+
+  const refresh = async (filename: string) => {
+    setRefreshingFilename(filename);
+
+    try {
+      const response = await fetch('/admin-api/credentials/models', {
+        body: JSON.stringify({ filename }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      const row = toCredentialModelRows(
+        (await response.json()) as CredentialModelResponse,
+      )[0];
+
+      if (!row) return;
+
+      setRows((current) =>
+        current.map((item) => (item.filename === filename ? row : item)),
+      );
+    } finally {
+      setRefreshingFilename(null);
+    }
+  };
+
+  const updateModels = (filename: string, value: string) => {
+    const models = parseSupportedModels(value);
+    setRows((current) =>
+      current.map((row) =>
+        row.filename === filename
+          ? { ...row, models, modelsInput: value }
+          : row,
+      ),
+    );
+  };
+
+  const saveModels = async (filename: string, models: string[]) => {
+    setSavingFilename(filename);
+
+    try {
+      const response = await fetch('/admin-api/credentials/models', {
+        body: JSON.stringify({ filename, models: models.join(', ') }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'PUT',
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to save supported models');
+      }
+    } finally {
+      setSavingFilename(null);
+    }
+  };
+
+  const scheduleSave = (filename: string, value: string) => {
+    const existingTimer = saveTimersRef.current.get(filename);
+    if (existingTimer) window.clearTimeout(existingTimer);
+
+    saveTimersRef.current.set(
+      filename,
+      window.setTimeout(() => {
+        saveTimersRef.current.delete(filename);
+        void saveModels(filename, parseSupportedModels(value));
+      }, 500),
+    );
+  };
+
+  const saveImmediately = (filename: string, value: string) => {
+    const existingTimer = saveTimersRef.current.get(filename);
+    if (existingTimer) window.clearTimeout(existingTimer);
+    saveTimersRef.current.delete(filename);
+    void saveModels(filename, parseSupportedModels(value));
+  };
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        setLoading(true);
+
+        try {
+          const response = await fetch('/admin-api/credentials/models');
+          setRows(
+            toCredentialModelRows(
+              (await response.json()) as CredentialModelResponse,
+            ),
+          );
+        } finally {
+          setLoading(false);
+        }
+      })();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  useEffect(
+    () => () => {
+      saveTimersRef.current.forEach((timer) => window.clearTimeout(timer));
+      saveTimersRef.current.clear();
+    },
+    [],
+  );
+
+  const columns: TableColumnsType<CredentialModelRow> = [
+    {
+      dataIndex: 'filename',
+      key: 'filename',
+      title: credentialsText('modelCredential'),
+      width: 220,
+    },
+    {
+      key: 'models',
+      render: (_, row) =>
+        row.error ? (
+          row.error
+        ) : (
+          <TextArea
+            className="credential-models-input"
+            disabled={savingFilename === row.filename}
+            onBlur={(event) =>
+              saveImmediately(row.filename, event.currentTarget.value)
+            }
+            onChange={(event) => {
+              updateModels(row.filename, event.target.value);
+              scheduleSave(row.filename, event.target.value);
+            }}
+            rows={3}
+            value={row.modelsInput}
+          />
+        ),
+      title: credentialsText('modelSupported'),
+      minWidth: 360,
+    },
+    {
+      key: 'refresh',
+      render: (_, row) => (
+        <Button
+          icon={RefreshCw}
+          loading={refreshingFilename === row.filename}
+          onClick={() => void refresh(row.filename)}
+        >
+          {common('refresh')}
+        </Button>
+      ),
+      title: credentialsText('modelRefresh'),
+      width: 130,
+    },
+  ];
+
+  return (
+    <Block
+      className="min-w-0 max-w-full"
+      direction="vertical"
+      gap={16}
+      padding={24}
+      variant="outlined"
+    >
+      <Flexbox align="center" gap={8} horizontal>
+        <Layers3 size={18} strokeWidth={2} />
+        <h3 className="section-title">{credentialsText('modelTableTitle')}</h3>
+      </Flexbox>
+      <div className="credential-models-table w-full min-w-0 max-w-full">
+        <Table<CredentialModelRow>
+          columns={columns}
+          dataSource={rows}
+          loading={loading}
+          pagination={false}
+          rowKey="filename"
+          scroll={{ x: 'max-content' }}
+          size="middle"
+        />
+      </div>
+    </Block>
+  );
+};
+
 const Settings = () => {
   const { onChange, onSave, settings } = useSettings();
   const translations = useTranslations('Admin');
+  const [clearingUsage, setClearingUsage] = useState(false);
+
+  const clearUsageEvents = async () => {
+    if (
+      !window.confirm(translations('settingsPanel.confirmClearUsageEvents'))
+    ) {
+      return;
+    }
+
+    setClearingUsage(true);
+
+    try {
+      await fetch('/admin-api/usage/clear', { method: 'POST' });
+    } finally {
+      setClearingUsage(false);
+    }
+  };
 
   return (
     <div className="block" id="settings">
@@ -175,6 +418,29 @@ const Settings = () => {
             type="primary"
           >
             {translations('common.save')}
+          </Button>
+        </Flexbox>
+      </Block>
+      <CredentialModels />
+      <Block direction="vertical" gap={16} padding={24} variant="outlined">
+        <Flexbox align="center" gap={8} horizontal>
+          <Trash2 size={18} strokeWidth={2} />
+          <h3 className="section-title">
+            {translations('settingsPanel.usageCacheTitle')}
+          </h3>
+        </Flexbox>
+        <p className="text-secondary">
+          {translations('settingsPanel.usageCacheDescription')}
+        </p>
+        <Flexbox horizontal>
+          <Button
+            danger
+            disabled={clearingUsage}
+            icon={Trash2}
+            loading={clearingUsage}
+            onClick={() => void clearUsageEvents()}
+          >
+            {translations('settingsPanel.clearUsageEvents')}
           </Button>
         </Flexbox>
       </Block>

--- a/app/usage/usage.tsx
+++ b/app/usage/usage.tsx
@@ -31,6 +31,7 @@ export interface UsageBucketPoint {
 }
 
 export interface UsageChartSeries {
+  color: string;
   model: string;
   points: UsageBucketPoint[];
 }
@@ -182,67 +183,6 @@ const useUsage = (): UsageController => {
   return controller;
 };
 
-const chartColors = [
-  '#1d4ed8',
-  '#ea580c',
-  '#059669',
-  '#9333ea',
-  '#dc2626',
-  '#0891b2',
-];
-
-const usageModelColorsStorageKey = 'codebuddy2api.usage.modelColors';
-
-const getDistinctChartColors = (models: string[]): Map<string, string> => {
-  const storedColors =
-    typeof window === 'undefined'
-      ? { hy3: chartColors[0] }
-      : (() => {
-          try {
-            return JSON.parse(
-              window.localStorage.getItem(usageModelColorsStorageKey) ?? '{}',
-            ) as Record<string, string>;
-          } catch {
-            return {} as Record<string, string>;
-          }
-        })();
-  storedColors.hy3 ??= chartColors[0];
-  const colors = new Map<string, string>();
-  const usedColors = new Set<string>();
-
-  models.forEach((model) => {
-    const storedColor = storedColors[model];
-    if (storedColor && !usedColors.has(storedColor)) {
-      colors.set(model, storedColor);
-      usedColors.add(storedColor);
-    }
-  });
-
-  models.forEach((model) => {
-    if (colors.has(model)) return;
-
-    const colorIndex = Array.from(colors).length;
-    const color =
-      chartColors.find((candidate) => !usedColors.has(candidate)) ??
-      `hsl(${colorIndex * 137.508}deg 68% 42%)`;
-    colors.set(model, color);
-    usedColors.add(color);
-  });
-
-  if (typeof window !== 'undefined') {
-    try {
-      window.localStorage.setItem(
-        usageModelColorsStorageKey,
-        JSON.stringify({ ...storedColors, ...Object.fromEntries(colors) }),
-      );
-    } catch {
-      // Keep the in-memory colors when browser storage is unavailable.
-    }
-  }
-
-  return colors;
-};
-
 const getMonotoneLinePath = (points: Array<{ x: number; y: number }>) => {
   if (!points.length) return '';
   if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
@@ -353,13 +293,8 @@ const UsageChart = ({
     (_, index) => gridStep * (index + 1),
   ).reverse();
   const yAxisValues = [...gridValues, 0];
-  const xLabelInterval = Math.max(1, Math.ceil((pointCount - 1) / 3));
+  const xLabelInterval = Math.max(1, Math.ceil((pointCount - 1) / 6));
   const axisLabelFontSize = width < 640 ? 11 : 8;
-  const modelColors = useMemo(
-    () => getDistinctChartColors(series.map((item) => item.model)),
-    [series],
-  );
-
   return (
     <Block direction="vertical" gap={16} padding={24} variant="outlined">
       <Flexbox align="center" gap={8} horizontal>
@@ -368,115 +303,146 @@ const UsageChart = ({
       </Flexbox>
       {series.length && pointCount ? (
         <div className="usage-chart relative">
-          <svg
-            aria-label={title}
-            className="usage-chart-svg h-auto w-full overflow-visible"
-            role="img"
-            viewBox={`0 0 ${width} ${height}`}
-          >
-            <title>{title}</title>
-            {yAxisValues.map((value) => {
-              const y = getY(value);
-              return (
-                <g key={`grid-${value}`}>
-                  <line
-                    className="stroke-border-light dark:stroke-border-dark"
-                    strokeWidth="1"
-                    vectorEffect="non-scaling-stroke"
-                    x1={padding.left}
-                    x2={width - padding.right}
-                    y1={y}
-                    y2={y}
-                  />
-                  <text
-                    className="fill-secondary"
-                    fontSize={axisLabelFontSize}
-                    textAnchor="end"
-                    x={padding.left - 10}
-                    y={y + 4}
-                  >
-                    {formatCompactNumber(locale, value)}
-                  </text>
-                </g>
-              );
-            })}
-            {series.map((item) => {
-              const color = modelColors.get(item.model)!;
-              const points = item.points.map((point, index) => ({
-                x: getX(index),
-                y: getY(point[metric]),
-              }));
-              return (
-                <g key={item.model}>
-                  <path
-                    d={getMonotoneLinePath(points)}
-                    fill="none"
-                    stroke={color}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="1.5"
-                    vectorEffect="non-scaling-stroke"
-                  />
-                  {item.points.map((point, index) => {
-                    const value = point[metric];
-                    const x = getX(index);
-                    const y = getY(value);
-                    const hover = () =>
-                      onHoverPoint({
-                        chart,
-                        label: point.label,
-                        metricLabel,
-                        model: item.model,
-                        value,
-                        x,
-                        y,
-                      });
-                    return (
-                      <circle
-                        cx={x}
-                        cy={y}
-                        fill={color}
-                        key={`${item.model}-${point.start}`}
-                        onBlur={() => onHoverPoint(null)}
-                        onFocus={hover}
-                        onMouseEnter={hover}
-                        onMouseLeave={() => onHoverPoint(null)}
-                        r="2"
-                        stroke="transparent"
-                        strokeWidth="8"
-                        tabIndex={0}
-                      />
-                    );
-                  })}
-                </g>
-              );
-            })}
-            {labels.map((label, index) => (
-              <text
-                className="fill-secondary"
-                fontSize={axisLabelFontSize}
-                key={`${title}-${label}`}
-                textAnchor={
-                  index === 0
-                    ? 'start'
-                    : index === labels.length - 1
-                      ? 'end'
-                      : 'middle'
-                }
-                x={getX(index)}
-                y={height - 10}
+          <div className="relative">
+            <svg
+              aria-label={title}
+              className="usage-chart-svg h-auto w-full overflow-visible"
+              role="img"
+              viewBox={`0 0 ${width} ${height}`}
+            >
+              <title>{title}</title>
+              {yAxisValues.map((value) => {
+                const y = getY(value);
+                return (
+                  <g key={`grid-${value}`}>
+                    <line
+                      className="stroke-border-light dark:stroke-border-dark"
+                      strokeWidth="1"
+                      vectorEffect="non-scaling-stroke"
+                      x1={padding.left}
+                      x2={width - padding.right}
+                      y1={y}
+                      y2={y}
+                    />
+                    <text
+                      className="fill-secondary"
+                      fontSize={axisLabelFontSize}
+                      textAnchor="end"
+                      x={padding.left - 10}
+                      y={y + 4}
+                    >
+                      {formatCompactNumber(locale, value)}
+                    </text>
+                  </g>
+                );
+              })}
+              {series.map((item) => {
+                const color = item.color;
+                const points = item.points.map((point, index) => ({
+                  x: getX(index),
+                  y: getY(point[metric]),
+                }));
+                return (
+                  <g key={item.model}>
+                    <path
+                      d={getMonotoneLinePath(points)}
+                      fill="none"
+                      stroke={color}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.5"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                    {item.points.map((point, index) => {
+                      const value = point[metric];
+                      const x = getX(index);
+                      const y = getY(value);
+                      const hover = () =>
+                        onHoverPoint({
+                          chart,
+                          label: point.label,
+                          metricLabel,
+                          model: item.model,
+                          value,
+                          x,
+                          y,
+                        });
+                      return (
+                        <circle
+                          cx={x}
+                          cy={y}
+                          fill={color}
+                          key={`${item.model}-${point.start}`}
+                          onBlur={() => onHoverPoint(null)}
+                          onFocus={hover}
+                          onMouseEnter={hover}
+                          onMouseLeave={() => onHoverPoint(null)}
+                          r="2"
+                          stroke="transparent"
+                          strokeWidth="8"
+                          tabIndex={0}
+                        />
+                      );
+                    })}
+                  </g>
+                );
+              })}
+              {labels.map((label, index) => (
+                <text
+                  className="fill-secondary"
+                  fontSize={axisLabelFontSize}
+                  key={`${title}-${label}`}
+                  textAnchor={
+                    index === 0
+                      ? 'start'
+                      : index === labels.length - 1
+                        ? 'end'
+                        : 'middle'
+                  }
+                  x={getX(index)}
+                  y={height - 10}
+                >
+                  {index === 0 ||
+                  index === labels.length - 1 ||
+                  index % xLabelInterval === 0
+                    ? label
+                    : ''}
+                </text>
+              ))}
+            </svg>
+            {hoveredPoint?.chart === chart ? (
+              <div
+                className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-[calc(100%+12px)]"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                  left: `${(hoveredPoint.x / width) * 100}%`,
+                  top: `${(hoveredPoint.y / height) * 100}%`,
+                }}
               >
-                {index === 0 ||
-                index === labels.length - 1 ||
-                index % xLabelInterval === 0
-                  ? label
-                  : ''}
-              </text>
-            ))}
-          </svg>
+                <Block
+                  className="min-w-44 text-xs"
+                  direction="vertical"
+                  gap={4}
+                  padding={12}
+                  variant="outlined"
+                >
+                  <div className="font-semibold">{hoveredPoint.model}</div>
+                  <div className="mt-1 text-secondary">
+                    {hoveredPoint.label}
+                  </div>
+                  <div className="mt-1">
+                    {hoveredPoint.metricLabel}:{' '}
+                    <span className="font-semibold">
+                      {formatNumber(locale, hoveredPoint.value)}
+                    </span>
+                  </div>
+                </Block>
+              </div>
+            ) : null}
+          </div>
           <Flexbox className="mt-3" gap={6} horizontal wrap="wrap">
             {series.map((item) => {
-              const color = modelColors.get(item.model)!;
+              const color = item.color;
               return (
                 <Flexbox align="center" gap={6} horizontal key={item.model}>
                   <span
@@ -496,33 +462,6 @@ const UsageChart = ({
               );
             })}
           </Flexbox>
-          {hoveredPoint?.chart === chart ? (
-            <div
-              className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full"
-              // eslint-disable-next-line react/forbid-dom-props
-              style={{
-                left: `${(hoveredPoint.x / width) * 100}%`,
-                top: `${(hoveredPoint.y / height) * 100}%`,
-              }}
-            >
-              <Block
-                className="min-w-44 text-xs"
-                direction="vertical"
-                gap={4}
-                padding={12}
-                variant="outlined"
-              >
-                <div className="font-semibold">{hoveredPoint.model}</div>
-                <div className="mt-1 text-secondary">{hoveredPoint.label}</div>
-                <div className="mt-1">
-                  {hoveredPoint.metricLabel}:{' '}
-                  <span className="font-semibold">
-                    {formatNumber(locale, hoveredPoint.value)}
-                  </span>
-                </div>
-              </Block>
-            </div>
-          ) : null}
         </div>
       ) : (
         <div className="py-12 text-center text-secondary">{emptyLabel}</div>

--- a/app/v1/models/route.ts
+++ b/app/v1/models/route.ts
@@ -13,5 +13,5 @@ export const GET = async (request: NextRequest): Promise<Response> => {
     return authError;
   }
 
-  return getModelsResponse();
+  return getModelsResponse(request);
 };

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,8 @@
+export const register = async (): Promise<void> => {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  const { refreshMissingCredentialModels } =
+    await import('@/lib/server/domain/credential-models');
+
+  void refreshMissingCredentialModels();
+};

--- a/lib/server/domain/config.ts
+++ b/lib/server/domain/config.ts
@@ -13,7 +13,6 @@ export interface RuntimeConfig {
   CODEBUDDY_AUTH_MODE: 'auto' | 'token';
   CODEBUDDY_INTERNET_ENVIRONMENT: 'ioa' | 'internal' | 'public';
   CODEBUDDY_LOG_LEVEL: string;
-  CODEBUDDY_MODELS: string;
 }
 
 export type ConfigLabelLocale = 'zh-CN' | 'en-US' | 'ja-JP';
@@ -26,8 +25,6 @@ const DEFAULT_CONFIG: RuntimeConfig = {
   CODEBUDDY_AUTH_MODE: 'auto',
   CODEBUDDY_INTERNET_ENVIRONMENT: 'ioa',
   CODEBUDDY_LOG_LEVEL: 'INFO',
-  CODEBUDDY_MODELS:
-    'glm-5.1,glm-5.0,glm-5.0-turbo,glm-5v-turbo,glm-4.7,minimax-m3-play,minimax-m2.7,minimax-m2.5,kimi-k2.6,kimi-k2.5,hy3-preview-agent,deepseek-v4-pro,deepseek-v4-flash,deepseek-v3-2-volc,claude-sonnet-4.6,claude-opus-4.8,claude-opus-4.8-1m,claude-opus-4.7,claude-opus-4.7-1m,claude-opus-4.6,claude-opus-4.6-1m,claude-haiku-4.5,gemini-3.1-pro,gemini-3.5-flash,gemini-2.5-pro,gpt-5.5,gpt-5.4,gpt-5.3-codex,gpt-5.1-codex,gpt-5.1-codex-mini,glm-5.2-ioa,glm-5v-turbo-ioa,glm-5.0-ioa,glm-4.7-ioa,minimax-m3-ioa,minimax-m2.7-ioa,minimax-m2.5-ioa,kimi-k2.6-ioa,hy3-preview-agent-ioa,deepseek-v4-pro-ioa,deepseek-v4-flash-ioa,deepseek-v3-2-volc-ioa',
 };
 let configMutationQueue: Promise<void> = Promise.resolve();
 
@@ -41,7 +38,6 @@ const SETTING_LABELS_BY_LOCALE: Record<
     CODEBUDDY_AUTH_MODE: 'Authentication mode (auto/token)',
     CODEBUDDY_INTERNET_ENVIRONMENT: 'Network environment (internal/ioa/public)',
     CODEBUDDY_LOG_LEVEL: 'Log level',
-    CODEBUDDY_MODELS: 'Available models (comma-separated)',
   },
   'ja-JP': {
     CODEBUDDY_API_ENDPOINT: 'CodeBuddy API エンドポイント',
@@ -49,7 +45,6 @@ const SETTING_LABELS_BY_LOCALE: Record<
     CODEBUDDY_AUTH_MODE: '認証モード (auto/token)',
     CODEBUDDY_INTERNET_ENVIRONMENT: 'ネットワーク環境 (internal/ioa/public)',
     CODEBUDDY_LOG_LEVEL: 'ログレベル',
-    CODEBUDDY_MODELS: '利用可能なモデル一覧 (カンマ区切り)',
   },
   'zh-CN': {
     CODEBUDDY_API_ENDPOINT: 'CodeBuddy 官方 API 端点',
@@ -57,7 +52,6 @@ const SETTING_LABELS_BY_LOCALE: Record<
     CODEBUDDY_AUTH_MODE: '认证模式 (auto/token)',
     CODEBUDDY_INTERNET_ENVIRONMENT: '网络环境 (internal/ioa/public)',
     CODEBUDDY_LOG_LEVEL: '日志级别',
-    CODEBUDDY_MODELS: '可用模型列表 (逗号分隔)',
   },
 };
 
@@ -130,10 +124,6 @@ export const getActiveConfig = async (): Promise<RuntimeConfig> => {
       'CODEBUDDY_LOG_LEVEL',
       persisted.CODEBUDDY_LOG_LEVEL ?? process.env.CODEBUDDY_LOG_LEVEL,
     ),
-    CODEBUDDY_MODELS: normalizeValue(
-      'CODEBUDDY_MODELS',
-      persisted.CODEBUDDY_MODELS ?? process.env.CODEBUDDY_MODELS,
-    ),
   };
 };
 
@@ -178,16 +168,7 @@ export const getCodeBuddyApiEndpoint = async (): Promise<string> => {
     : 'https://copilot.tencent.com';
 };
 
-export const getAvailableModels = async (): Promise<string[]> => {
-  return (await getActiveConfig()).CODEBUDDY_MODELS.split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
-};
-
-export const getDefaultModel = async (
-  fallback = 'glm-5.1',
-): Promise<string> => {
-  return (await getAvailableModels())[0] ?? fallback;
-};
+export const getDefaultModel = async (fallback = 'glm-5.1'): Promise<string> =>
+  fallback;
 
 export { getConfigDir, getConfigPath, getCredsDir, getFileStorageDir };

--- a/lib/server/domain/credential-models.ts
+++ b/lib/server/domain/credential-models.ts
@@ -1,0 +1,48 @@
+import {
+  getCredentialSupportedModels,
+  listEligibleCredentialRecords,
+  updateCredentialSupportedModels,
+} from './credentials';
+import { getModelsByCredential } from '../proxy/codebuddy';
+
+const globalCredentialModelRefreshState = globalThis as typeof globalThis & {
+  __codebuddy2apiCredentialModelRefresh__?: Promise<void>;
+};
+
+export const refreshMissingCredentialModels = (): Promise<void> => {
+  if (
+    !globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__
+  ) {
+    globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__ =
+      (async () => {
+        try {
+          const credentials = await listEligibleCredentialRecords();
+          const missingModels = credentials.filter(
+            (credential) =>
+              getCredentialSupportedModels(credential.data).length === 0,
+          );
+
+          await Promise.allSettled(
+            missingModels.map(async (credential) => {
+              const result = await getModelsByCredential([credential]);
+              const models = result[credential.filename]?.models ?? [];
+
+              if (models.length) {
+                await updateCredentialSupportedModels(
+                  credential.filename,
+                  models.map((model) => model.id),
+                );
+              }
+            }),
+          );
+        } catch (error) {
+          console.warn(
+            '[CodeBuddy2API] Unable to refresh missing credential models',
+            error,
+          );
+        }
+      })();
+  }
+
+  return globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__;
+};

--- a/lib/server/domain/credentials.ts
+++ b/lib/server/domain/credentials.ts
@@ -31,6 +31,7 @@ export type CredentialData = Record<string, unknown> & {
   user_info?: Record<string, unknown>;
   responses_passthrough?: boolean;
   first_message_role_to_system?: boolean;
+  supported_models?: string;
 };
 
 export interface CredentialRecord {
@@ -252,6 +253,23 @@ const getBooleanSetting = (value: unknown, fallback = false): boolean => {
   return fallback;
 };
 
+export const getCredentialSupportedModels = (
+  credential: CredentialData | null | undefined,
+): string[] => {
+  if (typeof credential?.supported_models !== 'string') {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      credential.supported_models
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
+};
+
 export const readCredentialRecords = async (): Promise<CredentialRecord[]> => {
   const items = await listStorageJson<CredentialData>('credentials');
 
@@ -364,6 +382,15 @@ const getEligibleRecords = (
 
     return true;
   });
+};
+
+export const listEligibleCredentialRecords = async (
+  allowedCredentialFilenames?: string[],
+): Promise<CredentialRecord[]> => {
+  return getEligibleRecords(
+    await readCredentialRecords(),
+    allowedCredentialFilenames,
+  );
 };
 
 const chooseNextRecord = (
@@ -603,6 +630,24 @@ export const updateCredentialByIndex = async (
   }
 
   return addCredential(credentialData, records[index].filename);
+};
+
+export const updateCredentialSupportedModels = async (
+  filename: string,
+  models: string[],
+): Promise<void> => {
+  const credential = await findCredentialRecordByFilename(filename);
+
+  if (!credential) {
+    throw new Error('Credential is unavailable');
+  }
+
+  await writeStorageJson('credentials', filename, {
+    ...credential.data,
+    supported_models: [
+      ...new Set(models.map((model) => model.trim()).filter(Boolean)),
+    ].join(','),
+  });
 };
 
 export const selectCredential = async (

--- a/lib/server/domain/debug.ts
+++ b/lib/server/domain/debug.ts
@@ -745,12 +745,15 @@ const getTraceUsage = (trace: DebugTrace): DebugUsageMetrics | null => {
     usage.output_tokens ?? usage.completion_tokens,
   );
   const promptTokenDetails = asRecord(usage.prompt_tokens_details);
-  const cacheReadTokens = toTokenCount(
-    usage.cache_read_input_tokens ?? promptTokenDetails?.cached_tokens,
+  const cacheReadTokens = Math.max(
+    toTokenCount(usage.cache_read_input_tokens),
+    toTokenCount(promptTokenDetails?.cached_tokens),
+    toTokenCount(usage.prompt_cache_hit_tokens),
   );
-  const cacheCreationTokens = toTokenCount(
-    usage.cache_creation_input_tokens ??
-      promptTokenDetails?.cache_creation_tokens,
+  const cacheCreationTokens = Math.max(
+    toTokenCount(usage.cache_creation_input_tokens),
+    toTokenCount(promptTokenDetails?.cache_creation_tokens),
+    toTokenCount(usage.prompt_cache_write_tokens),
   );
   const totalTokens =
     toTokenCount(usage.total_tokens) ||

--- a/lib/server/domain/usage.ts
+++ b/lib/server/domain/usage.ts
@@ -1,7 +1,11 @@
 import crypto from 'node:crypto';
 
 import { listAccessKeys } from './access-keys';
-import { listCredentialFilenames } from './credentials';
+import {
+  getCredentialSupportedModels,
+  listCredentialFilenames,
+  readCredentialRecords,
+} from './credentials';
 import {
   appendStorageUsageEvents,
   clearStorageUsageEvents,
@@ -18,6 +22,9 @@ export type UsageRange =
 export interface UsageSnapshot {
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
+  prompt_cache_hit_tokens?: number | null;
+  prompt_cache_miss_tokens?: number | null;
+  prompt_cache_write_tokens?: number | null;
   prompt_tokens_details?: {
     cached_tokens?: number | null;
     cache_creation_tokens?: number | null;
@@ -60,6 +67,7 @@ interface UsageBucket {
 }
 
 export interface UsageChartSeries {
+  color: string;
   model: string;
   points: Array<UsageBucketTotals & UsageBucket>;
 }
@@ -104,6 +112,14 @@ const DAY_MS = 24 * HOUR_MS;
 const FLUSH_INTERVAL_MS = 1000;
 const MAX_PENDING_EVENTS = 100;
 const RETENTION_PRUNE_INTERVAL_MS = HOUR_MS;
+const chartColors = [
+  '#1d4ed8',
+  '#ea580c',
+  '#059669',
+  '#9333ea',
+  '#dc2626',
+  '#0891b2',
+];
 let usageMutationQueue: Promise<void> = Promise.resolve();
 let pendingUsageEvents: UsageEventRecord[] = [];
 let usageFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -132,16 +148,23 @@ const toNumber = (value: unknown): number => {
   return numeric;
 };
 
+const getLargestTokenCount = (...values: unknown[]): number => {
+  return Math.max(0, ...values.map(toNumber));
+};
+
 const normalizeUsage = (usage: UsageSnapshot): UsageEventRecord => {
   const inputTokens = toNumber(usage.input_tokens ?? usage.prompt_tokens);
   const outputTokens = toNumber(usage.output_tokens ?? usage.completion_tokens);
   const promptTokenDetails = usage.prompt_tokens_details;
-  const cacheReadTokens = toNumber(
-    usage.cache_read_input_tokens ?? promptTokenDetails?.cached_tokens,
+  const cacheReadTokens = getLargestTokenCount(
+    usage.cache_read_input_tokens,
+    promptTokenDetails?.cached_tokens,
+    usage.prompt_cache_hit_tokens,
   );
-  const cacheCreationTokens = toNumber(
-    usage.cache_creation_input_tokens ??
-      promptTokenDetails?.cache_creation_tokens,
+  const cacheCreationTokens = getLargestTokenCount(
+    usage.cache_creation_input_tokens,
+    promptTokenDetails?.cache_creation_tokens,
+    usage.prompt_cache_write_tokens,
   );
   const explicitTotal = toNumber(usage.total_tokens);
   const totalTokens =
@@ -491,6 +514,15 @@ const createEmptyTotals = (): UsageBucketTotals => ({
   totalTokens: 0,
 });
 
+const createModelColors = (models: string[]): Record<string, string> => {
+  return Object.fromEntries(
+    models.map((model, index) => [
+      model,
+      chartColors[index] ?? `hsl(${(index * 137.508) % 360}deg 68% 42%)`,
+    ]),
+  );
+};
+
 const createEmptyBucketTotals = (count: number): UsageBucketTotals[] => {
   return Array.from({ length: count }, () => createEmptyTotals());
 };
@@ -669,10 +701,12 @@ export const getUsageAnalytics = async ({
 
     const toSeries = (
       modelMap: Map<string, UsageBucketTotals[]>,
+      modelColors: Record<string, string>,
     ): UsageChartSeries[] => {
       return [...modelMap.entries()]
         .sort((left, right) => left[0].localeCompare(right[0]))
         .map(([model, points]) => ({
+          color: modelColors[model] ?? '#64748b',
           model,
           points: points.map((point, index) => ({
             callCount: point.callCount,
@@ -684,8 +718,12 @@ export const getUsageAnalytics = async ({
         }));
     };
 
-    const accessKeys = await listAccessKeys();
-    const credentialFilenames = await listCredentialFilenames();
+    const [accessKeys, credentialFilenames, credentialRecords] =
+      await Promise.all([
+        listAccessKeys(),
+        listCredentialFilenames(),
+        readCredentialRecords(),
+      ]);
     const accessKeyHistoryOptions = [...store.events]
       .filter(
         (
@@ -721,8 +759,17 @@ export const getUsageAnalytics = async ({
         value,
       }));
 
+    const modelOrder = [
+      ...new Set(
+        credentialRecords.flatMap((record) =>
+          getCredentialSupportedModels(record.data),
+        ),
+      ),
+    ].sort((left, right) => left.localeCompare(right));
+    const modelColors = createModelColors(modelOrder);
+
     return {
-      callSeries: toSeries(callSeriesByModel),
+      callSeries: toSeries(callSeriesByModel, modelColors),
       credentialCallCounts,
       credentialRows: [...credentialRowsByFilename.entries()]
         .map(([credentialFilename, totals]) => ({
@@ -766,7 +813,7 @@ export const getUsageAnalytics = async ({
           model,
         }))
         .sort((left, right) => right.totalTokens - left.totalTokens),
-      tokenSeries: toSeries(tokenSeriesByModel),
+      tokenSeries: toSeries(tokenSeriesByModel, modelColors),
     };
   });
 };

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -1,16 +1,15 @@
 import type { NextRequest } from 'next/server';
 
 import { resolveRequestAccessKey } from './auth';
+import { getCodeBuddyApiEndpoint, getDefaultModel } from '../domain/config';
 import {
-  getAvailableModels,
-  getCodeBuddyApiEndpoint,
-  getDefaultModel,
-} from '../domain/config';
-import {
+  type CredentialData,
   type CredentialRecord,
   findEligibleCredentialRecordByFilename,
   findCredentialRecordByFilename,
+  getCredentialSupportedModels,
   getCredentialProxySettings,
+  listEligibleCredentialRecords,
   resolveCredentialForRequest,
 } from '../domain/credentials';
 import {
@@ -113,6 +112,11 @@ export interface ProxyContext {
     firstMessageRoleToSystem: boolean;
     responsesPassthrough: boolean;
   };
+}
+
+export interface DiscoveredModel {
+  displayName: string;
+  id: string;
 }
 
 const getCredentialAffinityKey = (
@@ -1100,11 +1104,193 @@ const aggregateUpstreamStream = async (
   };
 };
 
-export const getModelsResponse = async (): Promise<Response> => {
-  const models = (await getAvailableModels()).map((model) => ({
-    id: model,
-    slug: model,
-    display_name: model,
+export const getModelsForCredential = async ({
+  bearerToken,
+  credentialData,
+}: {
+  bearerToken: string;
+  credentialData: CredentialData;
+}): Promise<DiscoveredModel[]> => {
+  const endpoint = new URL(
+    '/console/enterprises/personal/models',
+    await getCodeBuddyApiEndpoint(),
+  );
+  const headers = new Headers({
+    Accept: 'application/json',
+    Authorization: `Bearer ${bearerToken}`,
+  });
+  const domain = getCredentialValue(credentialData, ['domain']);
+  const enterpriseId = getCredentialValue(credentialData, [
+    'enterprise_id',
+    'enterpriseId',
+  ]);
+  const tenantId =
+    getCredentialValue(credentialData, ['tenant_id', 'tenantId']) ??
+    enterpriseId;
+
+  if (domain) {
+    headers.set('X-Domain', String(domain));
+  }
+
+  if (enterpriseId) {
+    headers.set('X-Enterprise-Id', String(enterpriseId));
+  }
+
+  if (tenantId) {
+    headers.set('X-Tenant-Id', String(tenantId));
+  }
+
+  const response = await fetch(endpoint, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Model discovery failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    code?: unknown;
+    data?: {
+      agents?: Array<{ models?: unknown; name?: unknown }>;
+      models?: Array<{ disabled?: unknown; id?: unknown; name?: unknown }>;
+    };
+  };
+
+  if (payload.code !== 0) {
+    throw new Error('Model discovery returned an unsuccessful response');
+  }
+
+  const cliModels = payload.data?.agents?.find(
+    (agent) => agent.name === 'cli',
+  )?.models;
+  const modelsById = new Map(
+    (payload.data?.models ?? []).flatMap((model) => {
+      const id = typeof model.id === 'string' ? model.id.trim() : '';
+
+      if (!id || model.disabled === true) {
+        return [];
+      }
+
+      return [
+        [
+          id,
+          {
+            displayName:
+              typeof model.name === 'string' && model.name.trim()
+                ? model.name
+                : id,
+            id,
+          },
+        ] as const,
+      ];
+    }),
+  );
+
+  if (!Array.isArray(cliModels)) {
+    return [];
+  }
+
+  return cliModels.flatMap((modelId) => {
+    if (typeof modelId !== 'string') {
+      return [];
+    }
+
+    const model = modelsById.get(modelId);
+    return model ? [model] : [];
+  });
+};
+
+export const getModelsForCredentials = async (
+  credentials: CredentialRecord[],
+): Promise<DiscoveredModel[]> => {
+  const settled = await Promise.allSettled(
+    credentials.map((credential) => {
+      const supportedModels = getCredentialSupportedModels(credential.data);
+
+      if (supportedModels.length) {
+        return Promise.resolve(
+          supportedModels.map((id) => ({ displayName: id, id })),
+        );
+      }
+
+      const bearerToken = String(
+        credential.data.bearer_token ?? credential.data.access_token ?? '',
+      ).trim();
+
+      return bearerToken
+        ? getModelsForCredential({
+            bearerToken,
+            credentialData: credential.data,
+          })
+        : Promise.resolve([]);
+    }),
+  );
+  const models = new Map<string, DiscoveredModel>();
+
+  settled.forEach((result) => {
+    if (result.status !== 'fulfilled') {
+      return;
+    }
+
+    result.value.forEach((model) => {
+      models.set(model.id, model);
+    });
+  });
+
+  return [...models.values()].sort((left, right) =>
+    left.id.localeCompare(right.id),
+  );
+};
+
+export const getModelsByCredential = async (
+  credentials: CredentialRecord[],
+): Promise<
+  Record<string, { error: string | null; models: DiscoveredModel[] }>
+> => {
+  const results = await Promise.all(
+    credentials.map(async (credential) => {
+      const bearerToken = String(
+        credential.data.bearer_token ?? credential.data.access_token ?? '',
+      ).trim();
+
+      try {
+        const models = bearerToken
+          ? await getModelsForCredential({
+              bearerToken,
+              credentialData: credential.data,
+            })
+          : [];
+
+        return [credential.filename, { error: null, models }] as const;
+      } catch (error) {
+        return [
+          credential.filename,
+          {
+            error:
+              error instanceof Error ? error.message : 'Model discovery failed',
+            models: [],
+          },
+        ] as const;
+      }
+    }),
+  );
+
+  return Object.fromEntries(results);
+};
+
+export const getModelsResponse = async (
+  request?: NextRequest,
+): Promise<Response> => {
+  const accessKey = request ? await resolveRequestAccessKey(request) : null;
+  const models = (
+    await getModelsForCredentials(
+      await listEligibleCredentialRecords(accessKey?.credentialFilenames),
+    )
+  ).map((model) => ({
+    id: model.id,
+    slug: model.id,
+    display_name: model.displayName,
     object: 'model',
     created: 0,
     owned_by: 'codebuddy',

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -130,7 +130,7 @@
           "message79": "This dashboard believes in you 🌟",
           "message80": "Another day, another neat response 📬",
           "message81": "Keep the good packets coming 📦",
-          "message82": "Your filters look especially sharp today 🔎",
+          "message82": "Put those tokens to work today 🔎",
           "message83": "The server is stretching politely 🤸",
           "message84": "Good vibes, valid JSON 🧾",
           "message85": "Small wins count double today ✌️",
@@ -237,6 +237,10 @@
       "credentialRoleAsSystemTag": "developer → system",
       "credentialRoleKeepDeveloper": "Keep developer",
       "credentialSectionTitle": "Saved credentials",
+      "modelCredential": "Credential",
+      "modelRefresh": "Refresh",
+      "modelSupported": "Supported models",
+      "modelTableTitle": "Credential models",
       "credentialUserId": "User ID (optional)",
       "credentialUserIdPlaceholder": "Enter the user ID (optional)",
       "delete": "Delete",
@@ -254,7 +258,6 @@
       "examples": "API usage examples",
       "examplesCurl": "curl example:",
       "examplesPython": "Python example:",
-      "followCurrent": "Follow current rotation",
       "idle": "Click \"Send test\" to view the API response...",
       "message": "Test message",
       "model": "Model",
@@ -403,11 +406,15 @@
       "loginDescription": "Use the built-in admin login to establish the session cookie, then manage credentials, access keys, and passkeys from the console."
     },
     "settingsPanel": {
+      "clearUsageEvents": "Clear usage event cache",
+      "confirmClearUsageEvents": "Clear all stored usage events?",
       "helper": "The passkey RP ID should usually match the final site domain. HTTPS works directly; localhost is commonly allowed for local development, while other non-HTTPS domains usually cannot use passkeys.",
       "loading": "Loading settings...",
       "passkeyRpIdPlaceholder": "Leave empty to follow the current host",
       "saveSuccess": "Settings saved.",
-      "title": "Service settings"
+      "title": "Service settings",
+      "usageCacheDescription": "Remove all stored usage events. This cannot be undone.",
+      "usageCacheTitle": "Usage event cache"
     },
     "securityPanel": {
       "accountUpdated": "Administrator account updated.",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -130,7 +130,7 @@
           "message79": "このダッシュボードはあなたを信じています 🌟",
           "message80": "また一つ、整ったレスポンス 📬",
           "message81": "良いパケットを送り続けよう 📦",
-          "message82": "今日のフィルターは特に鋭いです 🔎",
+          "message82": "今日も Token をしっかり回そう 🔎",
           "message83": "サーバーが礼儀正しく伸びをしています 🤸",
           "message84": "いい気分と有効な JSON 🧾",
           "message85": "小さな勝利も今日は二倍 ✌️",
@@ -237,6 +237,10 @@
       "credentialRoleAsSystemTag": "developer → system",
       "credentialRoleKeepDeveloper": "developer を保持",
       "credentialSectionTitle": "保存済み認証情報",
+      "modelCredential": "認証情報",
+      "modelRefresh": "更新",
+      "modelSupported": "対応モデル",
+      "modelTableTitle": "認証情報モデル",
       "credentialUserId": "ユーザー ID (任意)",
       "credentialUserIdPlaceholder": "ユーザー ID を入力 (任意)",
       "delete": "削除",
@@ -254,7 +258,6 @@
       "examples": "API 利用例",
       "examplesCurl": "curl 例:",
       "examplesPython": "Python 例:",
-      "followCurrent": "現在のローテーションに従う",
       "idle": "「送信テスト」をクリックすると API 応答を表示します...",
       "message": "テストメッセージ",
       "model": "モデル",
@@ -403,11 +406,15 @@
       "loginDescription": "組み込みの管理者ログインで session cookie を作成し、その後コンソールから認証情報、Access Key、passkey を管理します。"
     },
     "settingsPanel": {
+      "clearUsageEvents": "使用量イベントキャッシュを削除",
+      "confirmClearUsageEvents": "保存済みの使用量イベントをすべて削除しますか？",
       "helper": "Passkey の RP ID は通常、最終的にアクセスするドメインと一致させます。HTTPS ではそのまま利用でき、localhost はローカル開発で使えることが多い一方、それ以外の非 HTTPS ドメインでは通常 passkey を利用できません。",
       "loading": "設定を読み込んでいます...",
       "passkeyRpIdPlaceholder": "空欄なら現在のホストに追従",
       "saveSuccess": "設定を保存しました。",
-      "title": "サービス設定"
+      "title": "サービス設定",
+      "usageCacheDescription": "保存済みの使用量イベントをすべて削除します。この操作は元に戻せません。",
+      "usageCacheTitle": "使用量イベントキャッシュ"
     },
     "securityPanel": {
       "accountUpdated": "管理者アカウントを更新しました。",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -130,7 +130,7 @@
           "message79": "这个仪表盘相信你 🌟",
           "message80": "又是一次整齐的响应 📬",
           "message81": "继续投递好数据包 📦",
-          "message82": "你的筛选器今天格外锋利 🔎",
+          "message82": "今天也把 Token 蹬起来 🔎",
           "message83": "服务器正在礼貌地伸懒腰 🤸",
           "message84": "好心情配合法 JSON 🧾",
           "message85": "今天的小胜利也算双份 ✌️",
@@ -233,6 +233,10 @@
       "credentialRoleAsSystemTag": "developer → system",
       "credentialRoleKeepDeveloper": "保留 developer",
       "credentialSectionTitle": "已保存的凭证",
+      "modelCredential": "凭据",
+      "modelRefresh": "刷新",
+      "modelSupported": "支持的模型",
+      "modelTableTitle": "凭据模型",
       "credentialUserId": "用户 ID (可选)",
       "credentialUserIdPlaceholder": "输入用户 ID (可选)",
       "delete": "删除",
@@ -250,7 +254,6 @@
       "examples": "API 使用示例",
       "examplesCurl": "curl 示例:",
       "examplesPython": "Python 示例:",
-      "followCurrent": "跟随当前轮询",
       "idle": "点击“发送测试”查看 API 响应...",
       "message": "测试消息",
       "model": "模型",
@@ -399,11 +402,15 @@
       "loginDescription": "使用内置管理员登录建立 session cookie，然后在控制台里管理凭证、Access Key 与 passkey。"
     },
     "settingsPanel": {
+      "clearUsageEvents": "清空用量统计缓存",
+      "confirmClearUsageEvents": "确认清空所有已保存的用量统计记录吗？",
       "helper": "Passkey RP ID 通常应与最终访问域名一致。HTTPS 站点可直接使用；localhost 在现代浏览器中通常可用于本地调试，其它非 HTTPS 域名通常无法使用 passkey。",
       "loading": "加载配置中...",
       "passkeyRpIdPlaceholder": "留空则跟随当前访问域名",
       "saveSuccess": "设置已保存。",
-      "title": "服务配置"
+      "title": "服务配置",
+      "usageCacheDescription": "删除所有已保存的用量统计记录。此操作无法撤销。",
+      "usageCacheTitle": "用量统计缓存"
     },
     "securityPanel": {
       "accountUpdated": "管理员账户已更新。",

--- a/tests/admin/initial-state.test.ts
+++ b/tests/admin/initial-state.test.ts
@@ -18,9 +18,10 @@ const createDashboardInitialData = (): DashboardInitialData => {
 
 const createApiTestInitialData = (): ApiTestInitialData => {
   return {
+    credentialModels: {},
     credentials: [],
     currentCredential: { status: 'empty' },
-    modelSettings: '',
+    models: [],
     tab: 'api-test',
   };
 };

--- a/tests/admin/page-loader.test.ts
+++ b/tests/admin/page-loader.test.ts
@@ -15,7 +15,13 @@ vi.mock('@/lib/server/domain/config', () => ({
 
 vi.mock('@/lib/server/domain/credentials', () => ({
   getCurrentCredentialInfo: vi.fn(),
+  listEligibleCredentialRecords: vi.fn(),
   listCredentials: vi.fn(),
+}));
+
+vi.mock('@/lib/server/proxy/codebuddy', () => ({
+  getModelsByCredential: vi.fn(),
+  getModelsForCredentials: vi.fn(),
 }));
 
 vi.mock('@/lib/server/domain/debug', () => ({
@@ -35,8 +41,13 @@ const { headers } = await import('next/headers');
 const { listAccessKeys } = await import('@/lib/server/domain/access-keys');
 const { getActiveConfig, getSettingLabels } =
   await import('@/lib/server/domain/config');
-const { getCurrentCredentialInfo, listCredentials } =
-  await import('@/lib/server/domain/credentials');
+const {
+  getCurrentCredentialInfo,
+  listEligibleCredentialRecords,
+  listCredentials,
+} = await import('@/lib/server/domain/credentials');
+const { getModelsByCredential, getModelsForCredentials } =
+  await import('@/lib/server/proxy/codebuddy');
 const { getDebugSettings, listDebugLogs } =
   await import('@/lib/server/domain/debug');
 const { getUsageStats } = await import('@/lib/server/domain/stats');
@@ -52,7 +63,10 @@ const domainLoaders = {
   getUsageStats,
   listAccessKeys,
   listCredentials,
+  listEligibleCredentialRecords,
   listDebugLogs,
+  getModelsByCredential,
+  getModelsForCredentials,
 };
 
 describe('tab-scoped initial data', () => {
@@ -62,12 +76,13 @@ describe('tab-scoped initial data', () => {
       new Headers({ host: 'admin.example.test' }) as never,
     );
     vi.mocked(listAccessKeys).mockResolvedValue({ access_keys: [] } as never);
-    vi.mocked(getActiveConfig).mockResolvedValue({
-      CODEBUDDY_MODELS: '',
-    } as never);
+    vi.mocked(getActiveConfig).mockResolvedValue({} as never);
     vi.mocked(getSettingLabels).mockReturnValue({} as never);
     vi.mocked(getCurrentCredentialInfo).mockResolvedValue({ status: 'empty' });
     vi.mocked(listCredentials).mockResolvedValue({ credentials: [] } as never);
+    vi.mocked(listEligibleCredentialRecords).mockResolvedValue([]);
+    vi.mocked(getModelsForCredentials).mockResolvedValue([]);
+    vi.mocked(getModelsByCredential).mockResolvedValue({});
     vi.mocked(getDebugSettings).mockResolvedValue({
       autoRefreshSeconds: 15,
       enabled: false,
@@ -90,7 +105,13 @@ describe('tab-scoped initial data', () => {
     ],
     [
       'api-test',
-      ['listCredentials', 'getCurrentCredentialInfo', 'getActiveConfig'],
+      [
+        'listCredentials',
+        'getCurrentCredentialInfo',
+        'listEligibleCredentialRecords',
+        'getModelsForCredentials',
+        'getModelsByCredential',
+      ],
     ],
     ['debug', ['getDebugSettings', 'listDebugLogs']],
     ['settings', ['getActiveConfig', 'getSettingLabels']],

--- a/tests/server/debug-usage.test.ts
+++ b/tests/server/debug-usage.test.ts
@@ -533,7 +533,7 @@ describe('debug and usage persistence', () => {
     });
     const stream =
       'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n' +
-      'data: {"usage":{"prompt_tokens":3,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":2}}}\n\n' +
+      'data: {"usage":{"prompt_tokens":3,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":2},"prompt_cache_hit_tokens":2,"cache_read_input_tokens":0}}\n\n' +
       'data: [DONE]\n\n';
 
     await enqueueAndConsumeUpstreamSnapshot(

--- a/tests/server/runtime.test.ts
+++ b/tests/server/runtime.test.ts
@@ -10,6 +10,7 @@ import * as AdminAccessKeysRoute from '@/app/admin-api/access-keys/route';
 import * as AdminCredentialsAutoRoute from '@/app/admin-api/credentials/auto/route';
 import * as AdminCredentialsCurrentRoute from '@/app/admin-api/credentials/current/route';
 import * as AdminCredentialsDeleteRoute from '@/app/admin-api/credentials/delete/route';
+import * as AdminCredentialsModelsRoute from '@/app/admin-api/credentials/models/route';
 import * as AdminCredentialsRoute from '@/app/admin-api/credentials/route';
 import * as AdminCredentialsSelectRoute from '@/app/admin-api/credentials/select/route';
 import * as AdminCredentialsToggleRoute from '@/app/admin-api/credentials/toggle-rotation/route';
@@ -111,7 +112,7 @@ describe('server runtime', () => {
     expect(healthPayload.active_credential).toBeUndefined();
     expect(modelsPayload.object).toBe('list');
     expect(Array.isArray(modelsPayload.data)).toBe(true);
-    expect(modelsPayload.data[0].id).toBeTruthy();
+    expect(modelsPayload.data).toEqual([]);
   });
 
   it('reports unhealthy when storage initialization fails', async () => {
@@ -123,6 +124,47 @@ describe('server runtime', () => {
 
     expect(response.status).toBe(503);
     expect((await response.json()).status).toBe('unhealthy');
+  });
+
+  it('preserves credential models when discovery fails', async () => {
+    const addResponse = await AdminCredentialsRoute.POST(
+      makeJsonRequest('http://localhost/admin-api/credentials', {
+        bearer_token: 'token-a',
+        user_id: 'alice@example.com',
+      }),
+    );
+    const { filename } = await addResponse.json();
+
+    await AdminCredentialsModelsRoute.PUT(
+      new Request('http://localhost/admin-api/credentials/models', {
+        body: JSON.stringify({ filename, models: 'glm-5.1,glm-4.7' }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'PUT',
+      }),
+    );
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(
+      new Error('Upstream unavailable'),
+    );
+
+    const refreshResponse = await AdminCredentialsModelsRoute.POST(
+      makeJsonRequest('http://localhost/admin-api/credentials/models', {
+        filename,
+      }),
+    );
+
+    expect(refreshResponse.status).toBe(200);
+    expect((await refreshResponse.json()).models[filename]).toEqual({
+      error: 'Upstream unavailable',
+      models: [],
+    });
+
+    const modelsResponse = await AdminCredentialsModelsRoute.GET(
+      new Request('http://localhost/admin-api/credentials/models'),
+    );
+    expect((await modelsResponse.json()).models[filename].models).toEqual([
+      { id: 'glm-5.1' },
+      { id: 'glm-4.7' },
+    ]);
   });
 
   it('manages settings and credentials through admin routes', async () => {

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -29,6 +29,9 @@ import {
 } from '@/lib/server/proxy/codebuddy-auth';
 import {
   createProxyContextFromCredential,
+  getModelsByCredential,
+  getModelsForCredential,
+  getModelsForCredentials,
   getModelsResponse,
   proxyChatCompletions,
   proxyResponsesUpstream,
@@ -39,13 +42,16 @@ import {
   deleteCredentialByIndex,
   getCurrentCredentialInfo,
   listCredentials,
+  readCredentialRecords,
   resetCredentialRuntimeState,
   resolveCredentialForRequest,
   resumeAutoRotation,
   selectCredential,
   toggleAutoRotation,
+  updateCredentialSupportedModels,
   updateCredentialByIndex,
 } from '@/lib/server/domain/credentials';
+import { refreshMissingCredentialModels } from '@/lib/server/domain/credential-models';
 import {
   handleResponsesRequest,
   resetResponseSessions,
@@ -546,10 +552,85 @@ describe('server units', () => {
     expect(reassigned?.filename).toBe(secondCredential.filename);
   });
 
+  it('refreshes only credentials missing saved models', async () => {
+    const refreshState = globalThis as typeof globalThis & {
+      __codebuddy2apiCredentialModelRefresh__?: Promise<void>;
+    };
+    delete refreshState.__codebuddy2apiCredentialModelRefresh__;
+
+    const first = await addCredential({ bearer_token: 'token-first' });
+    const second = await addCredential({ bearer_token: 'token-second' });
+    const existing = await addCredential({ bearer_token: 'token-existing' });
+    await updateCredentialSupportedModels(existing.filename, ['glm-existing']);
+    const defaultCredential = (await readCredentialRecords()).find(
+      (record) => record.data.bearer_token === 'default-test-token',
+    );
+    await updateCredentialSupportedModels(defaultCredential?.filename ?? '', [
+      'glm-default',
+    ]);
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            data: {
+              agents: [{ models: ['glm-5.1'], name: 'cli' }],
+              models: [{ id: 'glm-5.1', name: 'GLM 5.1' }],
+            },
+          }),
+        ),
+      )
+      .mockRejectedValueOnce(new Error('Upstream unavailable'))
+      .mockRejectedValue(new Error('Unexpected model discovery request'));
+
+    await refreshMissingCredentialModels();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const records = await readCredentialRecords();
+    const refreshedModels = [first.filename, second.filename].map(
+      (filename) =>
+        records.find((record) => record.filename === filename)?.data
+          .supported_models,
+    );
+    expect(refreshedModels).toContain('glm-5.1');
+    expect(refreshedModels).toContain(undefined);
+
+    delete refreshState.__codebuddy2apiCredentialModelRefresh__;
+  });
+
+  it('does not block startup when credential model refresh cannot read storage', async () => {
+    const refreshState = globalThis as typeof globalThis & {
+      __codebuddy2apiCredentialModelRefresh__?: Promise<void>;
+    };
+    delete refreshState.__codebuddy2apiCredentialModelRefresh__;
+    process.env.CODEBUDDY_STORAGE_BACKEND = 'pg';
+    process.env.CODEBUDDY_STORAGE_PG_URL = 'postgres://example.test/codebuddy';
+    resetStorageRuntime();
+    const warning = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    await expect(refreshMissingCredentialModels()).resolves.toBeUndefined();
+    expect(warning).toHaveBeenCalledWith(
+      '[CodeBuddy2API] Unable to refresh missing credential models',
+      expect.any(Error),
+    );
+
+    delete process.env.CODEBUDDY_STORAGE_BACKEND;
+    delete process.env.CODEBUDDY_STORAGE_PG_URL;
+    resetStorageRuntime();
+    delete refreshState.__codebuddy2apiCredentialModelRefresh__;
+  });
+
   it('persists usage history under file storage and preserves historical filters', async () => {
     const now = new Date('2026-07-11T12:30:00.000Z');
     vi.useFakeTimers();
     vi.setSystemTime(now);
+
+    await addCredential({
+      bearer_token: 'token-a',
+      supported_models: 'glm-4.7,glm-5.1',
+    });
 
     await recordUsageEvent({
       accessKeyId: 'key-1',
@@ -600,6 +681,7 @@ describe('server units', () => {
       model: 'glm-5.1',
       totalTokens: 20,
     });
+    expect(analytics.callSeries[0]?.color).toBe('#ea580c');
 
     await recordUsageEvent({
       accessKeyId: 'key-1',
@@ -1269,6 +1351,49 @@ describe('server units', () => {
           totalTokens: 0,
         },
       ],
+    });
+  });
+
+  it('records CodeBuddy prompt cache hits from streamed usage', async () => {
+    const credential = (await listCredentials()).credentials[0];
+    expect(credential).toBeDefined();
+
+    const context = await resolveProxyContextByCredentialFilename(
+      String(credential?.filename),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        'data: {"choices":[{"delta":{"content":"cached"}}]}\n\n' +
+          'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":125823,"completion_tokens":56,"total_tokens":125879,"prompt_tokens_details":{"cached_tokens":125376},"prompt_cache_hit_tokens":125376,"cache_read_input_tokens":0}}\n\n' +
+          'data: [DONE]\n\n',
+        {
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+          },
+        },
+      ),
+    );
+
+    const response = await proxyChatCompletions(
+      makeNextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      {
+        messages: [{ content: 'cached request', role: 'user' }],
+        stream: true,
+      },
+      context,
+    );
+    await response.text();
+
+    await waitForAsync(async () => {
+      expect(
+        (await getUsageAnalytics({ range: 'today' })).rangeSummary,
+      ).toEqual({
+        cacheHitTokens: 125376,
+        callCount: 1,
+        totalTokens: 125879,
+      });
     });
   });
 
@@ -2644,24 +2769,150 @@ describe('server units', () => {
     expect(resolved.preferences.responsesPassthrough).toBe(false);
   });
 
+  it('discovers models per credential without live upstream requests', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch');
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            data: {
+              agents: [{ models: ['glm-5.1', 'disabled', 42], name: 'cli' }],
+              models: [
+                { id: 'glm-5.1', name: 'GLM 5.1' },
+                { disabled: true, id: 'disabled', name: 'Disabled' },
+                { id: 'fallback-name', name: '   ' },
+              ],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 1 })))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, data: { models: [] } })),
+      )
+      .mockRejectedValue(new Error('Upstream unavailable'));
+
+    await expect(
+      getModelsForCredential({
+        bearerToken: 'token-a',
+        credentialData: {
+          domain: 'example.com',
+          enterprise_id: 'enterprise-a',
+          tenant_id: 'tenant-a',
+        },
+      }),
+    ).resolves.toEqual([{ displayName: 'GLM 5.1', id: 'glm-5.1' }]);
+    const requestInit = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(requestInit?.headers);
+    expect(headers.get('authorization')).toBe('Bearer token-a');
+    expect(headers.get('x-domain')).toBe('example.com');
+    expect(headers.get('x-enterprise-id')).toBe('enterprise-a');
+    expect(headers.get('x-tenant-id')).toBe('tenant-a');
+
+    await expect(
+      getModelsForCredential({ bearerToken: 'token-b', credentialData: {} }),
+    ).rejects.toThrow('Model discovery failed with status 503');
+    await expect(
+      getModelsForCredential({ bearerToken: 'token-c', credentialData: {} }),
+    ).rejects.toThrow('Model discovery returned an unsuccessful response');
+    await expect(
+      getModelsForCredential({ bearerToken: 'token-d', credentialData: {} }),
+    ).resolves.toEqual([]);
+
+    const records = [
+      {
+        data: { supported_models: 'glm-saved,glm-other' },
+        filePath: '',
+        filename: 'saved.json',
+      },
+      {
+        data: { bearer_token: 'token-failing' },
+        filePath: '',
+        filename: 'failing.json',
+      },
+      { data: {}, filePath: '', filename: 'empty.json' },
+    ];
+    await expect(getModelsForCredentials(records)).resolves.toEqual([
+      { displayName: 'glm-other', id: 'glm-other' },
+      { displayName: 'glm-saved', id: 'glm-saved' },
+    ]);
+    await expect(getModelsByCredential(records)).resolves.toEqual({
+      'empty.json': { error: null, models: [] },
+      'failing.json': { error: 'Upstream unavailable', models: [] },
+      'saved.json': { error: null, models: [] },
+    });
+  });
+
   it('returns models in both OpenAI-compatible and admin-friendly shapes', async () => {
-    const payload = (await (await getModelsResponse()).json()) as {
+    const secondCredential = await addCredential({
+      bearer_token: 'second-model-token',
+      user_id: 'second-model@example.com',
+    });
+    const credentials = await listCredentials();
+    const accessKey = await createAccessKey({
+      credentialFilenames: [
+        credentials.credentials[0].filename as string,
+        secondCredential.filename,
+      ],
+      name: 'Model Discovery Key',
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (_input, init) => {
+        const token = new Headers(init?.headers).get('authorization');
+        const models =
+          token === 'Bearer second-model-token'
+            ? [
+                { id: 'shared-model', name: 'Shared' },
+                { id: 'second-model', name: 'Second' },
+              ]
+            : [
+                { id: 'default-model', name: 'Default' },
+                { disabled: true, id: 'disabled-model', name: 'Disabled' },
+                { id: 'shared-model', name: 'Shared' },
+              ];
+
+        return makeJsonResponse({
+          code: 0,
+          data: {
+            agents: [
+              {
+                models: models.map((model) => model.id),
+                name: 'cli',
+              },
+            ],
+            models,
+          },
+        });
+      });
+    const payload = (await (
+      await getModelsResponse(
+        makeNextRequest('http://localhost/v1/models', {
+          headers: { authorization: `Bearer ${accessKey.secret}` },
+        }),
+      )
+    ).json()) as {
       data: Array<Record<string, unknown>>;
       models: Array<Record<string, unknown>>;
     };
 
-    expect(payload.data.length).toBeGreaterThan(0);
+    expect(secondCredential.filename).toBeTruthy();
     expect(payload.models).toEqual(payload.data);
-    expect(payload.data[0]).toEqual(
-      expect.objectContaining({
-        created: 0,
-        display_name: expect.any(String),
-        id: expect.any(String),
-        object: 'model',
-        owned_by: 'codebuddy',
-        slug: expect.any(String),
-      }),
+    expect(payload.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'default-model' }),
+        expect.objectContaining({ id: 'second-model' }),
+        expect.objectContaining({ id: 'shared-model' }),
+      ]),
     );
+    expect(payload.data).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'disabled-model' }),
+      ]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('keeps empty streamed assistant content for previous_response_id follow-ups', async () => {


### PR DESCRIPTION
## Summary
- discover and persist supported models per credential across file, SQLite, and PostgreSQL storage
- expose per-credential model refresh and automatic model saves in Settings
- refresh eligible credentials missing saved models when the application starts
- return saved models for the selected credential in model APIs and API Test
- fix cache-hit aggregation, DebugView output-token TPS, responsive navigation, and small-screen credential rendering

## Validation
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage
- bun run test:ci
- bun run build