### PR TITLE
fix: cancel disconnected upstream streams

### DIFF
--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -813,10 +813,17 @@ const mapOpenAIStreamToAnthropicSSE = (
     });
   };
 
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+  const releaseReader = (): void => {
+    reader?.releaseLock();
+    reader = null;
+  };
   const stream = new ReadableStream<Uint8Array>({
     start: (ctrl) => {
       controller = ctrl;
-      const reader = upstreamResponse.body!.getReader();
+      const upstreamReader = upstreamResponse.body!.getReader();
+      reader = upstreamReader;
       let buffer = '';
 
       const flushFrames = (frames: string[]): void => {
@@ -845,7 +852,11 @@ const mapOpenAIStreamToAnthropicSSE = (
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await reader.read();
+        const { done, value } = await upstreamReader.read();
+
+        if (cancelled) {
+          return;
+        }
 
         if (done) {
           if (buffer.trim()) {
@@ -853,6 +864,7 @@ const mapOpenAIStreamToAnthropicSSE = (
           }
 
           finalize();
+          releaseReader();
           controller.close();
           return;
         }
@@ -865,6 +877,14 @@ const mapOpenAIStreamToAnthropicSSE = (
       };
 
       void pump();
+    },
+    async cancel(reason): Promise<void> {
+      cancelled = true;
+      try {
+        await reader?.cancel(reason);
+      } finally {
+        releaseReader();
+      }
     },
   });
 

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -222,9 +222,16 @@ const trackResponsesUsageStream = async ({
 
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+  const releaseReader = (): void => {
+    reader?.releaseLock();
+    reader = null;
+  };
   const stream = new ReadableStream<Uint8Array>({
     start: (controller) => {
-      const reader = upstreamResponse.body!.getReader();
+      const upstreamReader = upstreamResponse.body!.getReader();
+      reader = upstreamReader;
       let buffer = '';
       let latestUsage = fallbackUsage;
 
@@ -250,7 +257,11 @@ const trackResponsesUsageStream = async ({
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await reader.read();
+        const { done, value } = await upstreamReader.read();
+
+        if (cancelled) {
+          return;
+        }
 
         if (done) {
           if (buffer) {
@@ -264,6 +275,7 @@ const trackResponsesUsageStream = async ({
             route: '/v1/responses',
             usage: latestUsage,
           });
+          releaseReader();
           controller.close();
           return;
         }
@@ -282,6 +294,14 @@ const trackResponsesUsageStream = async ({
       };
 
       void pump();
+    },
+    async cancel(reason): Promise<void> {
+      cancelled = true;
+      try {
+        await reader?.cancel(reason);
+      } finally {
+        releaseReader();
+      }
     },
   });
 
@@ -897,10 +917,17 @@ const normalizeStreamingResponse = ({
     mappings: new Map<string, ToolCallMapping>(),
     nextIndex: 0,
   };
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+  const releaseReader = (): void => {
+    reader?.releaseLock();
+    reader = null;
+  };
 
   const stream = new ReadableStream<Uint8Array>({
     start: (controller) => {
-      const reader = upstreamResponse.body!.getReader();
+      const upstreamReader = upstreamResponse.body!.getReader();
+      reader = upstreamReader;
       let buffer = '';
       let latestUsage: unknown = null;
 
@@ -938,7 +965,11 @@ const normalizeStreamingResponse = ({
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await reader.read();
+        const { done, value } = await upstreamReader.read();
+
+        if (cancelled) {
+          return;
+        }
 
         if (done) {
           if (buffer.trim()) {
@@ -952,6 +983,7 @@ const normalizeStreamingResponse = ({
             usage: latestUsage,
           });
 
+          releaseReader();
           controller.close();
           return;
         }
@@ -964,6 +996,14 @@ const normalizeStreamingResponse = ({
       };
 
       void pump();
+    },
+    async cancel(reason): Promise<void> {
+      cancelled = true;
+      try {
+        await reader?.cancel(reason);
+      } finally {
+        releaseReader();
+      }
     },
   });
 

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -1011,12 +1011,19 @@ const createResponsesEventStream = async (
   const toolCallStates = new Map<string, StreamingToolCallState>();
   const toolCallStateKeys = new Map<string, string>();
   let nextToolCallOutputIndex = 1;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+  const releaseReader = (): void => {
+    reader?.releaseLock();
+    reader = null;
+  };
 
   const stream = new ReadableStream<Uint8Array>({
     start: (controller) => {
       const encoder = new TextEncoder();
       const decoder = new TextDecoder();
-      const reader = upstreamResponse.body!.getReader();
+      const upstreamReader = upstreamResponse.body!.getReader();
+      reader = upstreamReader;
       let buffer = '';
 
       const enqueueEvent = (payload: Record<string, unknown>): void => {
@@ -1129,7 +1136,11 @@ const createResponsesEventStream = async (
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await reader.read();
+        const { done, value } = await upstreamReader.read();
+
+        if (cancelled) {
+          return;
+        }
 
         if (done) {
           const transcriptToolCalls =
@@ -1221,6 +1232,7 @@ const createResponsesEventStream = async (
             },
           });
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          releaseReader();
           controller.close();
           return;
         }
@@ -1352,6 +1364,14 @@ const createResponsesEventStream = async (
       };
 
       void pump();
+    },
+    async cancel(reason): Promise<void> {
+      cancelled = true;
+      try {
+        await reader?.cancel(reason);
+      } finally {
+        releaseReader();
+      }
     },
   });
 

--- a/tests/server/anthropic.test.ts
+++ b/tests/server/anthropic.test.ts
@@ -565,6 +565,36 @@ describe('anthropic messages api', () => {
     expect(text).toContain('event: message_stop');
   });
 
+  it('cancels the upstream Chat stream when an Anthropic client disconnects', async () => {
+    const cancel = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel,
+        }),
+        {
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+          },
+        },
+      ),
+    );
+
+    const response = await handleMessagesRequest(
+      makeNextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        model: 'claude-sonnet-4.6',
+        max_tokens: 1024,
+        stream: true,
+        messages: [{ role: 'user', content: 'cancel me' }],
+      },
+    );
+
+    await response.body?.cancel('client disconnected');
+
+    expect(cancel).toHaveBeenCalledWith('client disconnected');
+  });
+
   it('handles streaming with tool_use blocks', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       makeSseResponse([

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -2019,6 +2019,31 @@ describe('server units', () => {
     expect(await streamResponse.text()).toContain('response.error');
   });
 
+  it('cancels the upstream Chat stream when a Responses client disconnects', async () => {
+    const cancel = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel,
+        }),
+        {
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+          },
+        },
+      ),
+    );
+
+    const response = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'cancel me', model: 'gpt-5.5', stream: true },
+    );
+
+    await response.body?.cancel('client disconnected');
+
+    expect(cancel).toHaveBeenCalledWith('client disconnected');
+  });
+
   it('maps mcp tool calls back to responses mcp items', async () => {
     process.env.CODEBUDDY_AUTH_MODE = 'api_key';
     process.env.CODEBUDDY_API_KEY = 'cb-key';
@@ -2414,6 +2439,31 @@ describe('server units', () => {
         },
       ]);
     });
+  });
+
+  it('cancels the upstream Responses stream when the client disconnects', async () => {
+    const cancel = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel,
+        }),
+        {
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+          },
+        },
+      ),
+    );
+
+    const response = await proxyResponsesUpstream(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'cancel me', model: 'gpt-5.5', stream: true },
+    );
+
+    await response.body?.cancel('client disconnected');
+
+    expect(cancel).toHaveBeenCalledWith('client disconnected');
   });
 
   it('covers responses passthrough header fallback, raw body passthrough, and upstream errors', async () => {


### PR DESCRIPTION
## Summary
- cancel and unlock upstream readers when streaming clients disconnect
- release readers after normal stream completion
- cover Responses passthrough, Responses adapter, and Anthropic adapter cancellation

## Validation
- bun run test -- tests/server/units.test.ts tests/server/anthropic.test.ts
- bun run test:coverage
- bun run test:ci
- bun run lint
- bun run format:check
- bun run typecheck
- bun run build