### PR TITLE
Improve streaming robustness, add API test abort, and cap buffered logs/events

### DIFF
--- a/app/page-shell.tsx
+++ b/app/page-shell.tsx
@@ -376,6 +376,7 @@ const AdminPageLayoutContent = ({
     },
   ] as const;
   const authPollTimerRef = useRef<number | null>(null);
+  const apiTestAbortControllerRef = useRef<AbortController | null>(null);
   const debugAutoRefreshTimerRef = useRef<number | null>(null);
   const usageAutoRefreshTimerRef = useRef<number | null>(null);
   const usageRequestRef = useRef(usage.request);
@@ -1264,6 +1265,9 @@ const AdminPageLayoutContent = ({
   };
 
   const testApi = async () => {
+    apiTestAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    apiTestAbortControllerRef.current = abortController;
     setApiTest((current) => ({
       ...current,
       result: consoleMessages.requestSending,
@@ -1286,6 +1290,7 @@ const AdminPageLayoutContent = ({
         'Content-Type': 'application/json',
       },
       method: 'POST',
+      signal: abortController.signal,
     });
     if (!response.ok) {
       const text = await response.text();
@@ -1321,21 +1326,25 @@ const AdminPageLayoutContent = ({
       let streamedResult = '';
       let done = false;
 
-      while (!done) {
-        const next = await reader.read();
-        done = next.done;
-        buffered += decoder.decode(next.value, { stream: !done });
-        const events = buffered.split(/\r?\n\r?\n/);
-        buffered = events.pop() ?? '';
-        const nextContent = events.map(getSseEventContent).join('');
+      try {
+        while (!done) {
+          const next = await reader.read();
+          done = next.done;
+          buffered += decoder.decode(next.value, { stream: !done });
+          const events = buffered.split(/\r?\n\r?\n/);
+          buffered = events.pop() ?? '';
+          const nextContent = events.map(getSseEventContent).join('');
 
-        if (nextContent) {
-          streamedResult += nextContent;
-          setApiTest((current) => ({
-            ...current,
-            result: streamedResult,
-          }));
+          if (nextContent) {
+            streamedResult += nextContent;
+            setApiTest((current) => ({
+              ...current,
+              result: streamedResult,
+            }));
+          }
         }
+      } finally {
+        reader.releaseLock();
       }
 
       const finalContent = getSseEventContent(buffered);
@@ -1553,6 +1562,8 @@ const AdminPageLayoutContent = ({
     }
 
     return () => {
+      apiTestAbortControllerRef.current?.abort();
+      apiTestAbortControllerRef.current = null;
       clearAuthTimer();
       clearDebugAutoRefreshTimer();
       clearUsageTimer();

--- a/lib/server/domain/credential-models.ts
+++ b/lib/server/domain/credential-models.ts
@@ -38,27 +38,30 @@ export const refreshMissingCredentialModels = (): Promise<void> => {
   if (
     !globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__
   ) {
-    globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__ =
-      (async () => {
-        try {
-          const credentials = await listEligibleCredentialRecords();
-          const missingModels = credentials.filter(
-            (credential) =>
-              getCredentialSupportedModels(credential.data).length === 0,
-          );
+    const refresh = (async () => {
+      try {
+        const credentials = await listEligibleCredentialRecords();
+        const missingModels = credentials.filter(
+          (credential) =>
+            getCredentialSupportedModels(credential.data).length === 0,
+        );
 
-          await Promise.allSettled(
-            missingModels.map(async (credential) => {
-              await refreshCredentialModels(credential.filename);
-            }),
-          );
-        } catch (error) {
-          console.warn(
-            '[CodeBuddy2API] Unable to refresh missing credential models',
-            error,
-          );
-        }
-      })();
+        await Promise.allSettled(
+          missingModels.map(async (credential) => {
+            await refreshCredentialModels(credential.filename);
+          }),
+        );
+      } catch (error) {
+        console.warn(
+          '[CodeBuddy2API] Unable to refresh missing credential models',
+          error,
+        );
+      }
+    })();
+    globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__ =
+      refresh.finally(() => {
+        delete globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__;
+      });
   }
 
   return globalCredentialModelRefreshState.__codebuddy2apiCredentialModelRefresh__;

--- a/lib/server/domain/credentials.ts
+++ b/lib/server/domain/credentials.ts
@@ -54,6 +54,9 @@ interface ManagerState {
 
 const globalCredentialState = globalThis as typeof globalThis & {
   __codebuddy2apiCredentialState__?: ManagerState;
+  __codebuddy2apiCredentialSignalHandlers__?: Partial<
+    Record<NodeJS.Signals, () => void>
+  >;
 };
 
 const MANAGER_STATE_FILENAME = 'manager_state.json';
@@ -184,13 +187,26 @@ const flushRuntimeStateBeforeShutdown = (signal: NodeJS.Signals): void => {
     });
 };
 
-process.once('SIGTERM', () => {
-  flushRuntimeStateBeforeShutdown('SIGTERM');
-});
+const installShutdownHandler = (signal: NodeJS.Signals): void => {
+  const previousHandler =
+    globalCredentialState.__codebuddy2apiCredentialSignalHandlers__?.[signal];
 
-process.once('SIGINT', () => {
-  flushRuntimeStateBeforeShutdown('SIGINT');
-});
+  if (previousHandler) {
+    process.removeListener(signal, previousHandler);
+  }
+
+  const handler = (): void => {
+    flushRuntimeStateBeforeShutdown(signal);
+  };
+  globalCredentialState.__codebuddy2apiCredentialSignalHandlers__ = {
+    ...globalCredentialState.__codebuddy2apiCredentialSignalHandlers__,
+    [signal]: handler,
+  };
+  process.once(signal, handler);
+};
+
+installShutdownHandler('SIGTERM');
+installShutdownHandler('SIGINT');
 
 const getNestedValue = (
   value: unknown,

--- a/lib/server/domain/debug.ts
+++ b/lib/server/domain/debug.ts
@@ -84,6 +84,7 @@ const MAX_SNAPSHOT_TEXT_LENGTH = 200_000;
 const FLUSH_INTERVAL_MS = 1000;
 const DEBUG_SETTINGS_CACHE_TTL_MS = 1000;
 const MAX_PENDING_LOGS = 100;
+const MAX_BUFFERED_LOGS = 1_000;
 const REDACTED_VALUE = '[redacted]';
 let debugWriteQueue: Promise<void> = Promise.resolve();
 let pendingDebugLogs: DebugLogEntry[] = [];
@@ -569,8 +570,12 @@ const captureResponseSnapshot = (
   const reader = response.body.getReader();
   const body = new ReadableStream<Uint8Array>({
     async cancel(reason): Promise<void> {
-      await reader.cancel(reason);
-      finish();
+      try {
+        await reader.cancel(reason);
+      } finally {
+        finish();
+        reader.releaseLock();
+      }
     },
     async pull(controller): Promise<void> {
       try {
@@ -638,7 +643,7 @@ const readSnapshotText = async (response: Response): Promise<string> => {
     }
   } finally {
     if (truncated) {
-      void reader.cancel().catch(() => undefined);
+      await reader.cancel().catch(() => undefined);
     }
     reader.releaseLock();
   }
@@ -794,6 +799,10 @@ export const enqueueUpstreamResponseSnapshot = (
 
 const appendDebugLog = async (entry: DebugLogEntry): Promise<void> => {
   pendingDebugLogs.push(entry);
+  pendingDebugLogs.splice(
+    0,
+    Math.max(0, pendingDebugLogs.length - MAX_BUFFERED_LOGS),
+  );
 
   if (pendingDebugLogs.length >= MAX_PENDING_LOGS) {
     void flushPendingDebugLogs().catch(() => undefined);
@@ -847,7 +856,9 @@ const flushPendingDebugLogs = async (): Promise<void> => {
       }
     });
   } catch (error) {
-    pendingDebugLogs = [...entries, ...pendingDebugLogs];
+    pendingDebugLogs = [...entries, ...pendingDebugLogs].slice(
+      -MAX_BUFFERED_LOGS,
+    );
     scheduleDebugFlush();
     throw error;
   } finally {

--- a/lib/server/domain/usage.ts
+++ b/lib/server/domain/usage.ts
@@ -111,6 +111,7 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const FLUSH_INTERVAL_MS = 1000;
 const MAX_PENDING_EVENTS = 100;
+const MAX_BUFFERED_EVENTS = 1_000;
 const RETENTION_PRUNE_INTERVAL_MS = HOUR_MS;
 const chartColors = [
   '#1d4ed8',
@@ -338,7 +339,9 @@ const flushPendingUsageEvents = async (): Promise<void> => {
       }
     });
   } catch (error) {
-    pendingUsageEvents = [...events, ...pendingUsageEvents];
+    pendingUsageEvents = [...events, ...pendingUsageEvents].slice(
+      -MAX_BUFFERED_EVENTS,
+    );
     scheduleUsageFlush();
     throw error;
   }
@@ -584,6 +587,10 @@ export const recordUsageEvent = async ({
     route,
     timestamp: timestamp ?? new Date().toISOString(),
   });
+  pendingUsageEvents.splice(
+    0,
+    Math.max(0, pendingUsageEvents.length - MAX_BUFFERED_EVENTS),
+  );
 
   if (pendingUsageEvents.length >= MAX_PENDING_EVENTS) {
     void flushPendingUsageEvents().catch(() => undefined);

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -873,10 +873,17 @@ const mapOpenAIStreamToAnthropicSSE = (
         const frames = buffer.split('\n\n');
         buffer = frames.pop() ?? '';
         flushFrames(frames);
-        await pump();
+        continuePumping();
       };
 
-      void pump();
+      const continuePumping = (): void => {
+        void pump().catch((error: unknown) => {
+          releaseReader();
+          if (!cancelled) controller.error(error);
+        });
+      };
+
+      continuePumping();
     },
     async cancel(reason): Promise<void> {
       cancelled = true;

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -290,10 +290,17 @@ const trackResponsesUsageStream = async ({
           controller.enqueue(encoder.encode(`${frame}\n\n`));
         });
 
-        await pump();
+        continuePumping();
       };
 
-      void pump();
+      const continuePumping = (): void => {
+        void pump().catch((error: unknown) => {
+          releaseReader();
+          if (!cancelled) controller.error(error);
+        });
+      };
+
+      continuePumping();
     },
     async cancel(reason): Promise<void> {
       cancelled = true;
@@ -982,10 +989,17 @@ const normalizeStreamingResponse = ({
         const frames = buffer.split('\n\n');
         buffer = frames.pop() ?? '';
         flushFrames(frames);
-        await pump();
+        continuePumping();
       };
 
-      void pump();
+      const continuePumping = (): void => {
+        void pump().catch((error: unknown) => {
+          releaseReader();
+          if (!cancelled) controller.error(error);
+        });
+      };
+
+      continuePumping();
     },
     async cancel(reason): Promise<void> {
       cancelled = true;

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -1361,10 +1361,17 @@ const createResponsesEventStream = async (
           }
         });
 
-        await pump();
+        continuePumping();
       };
 
-      void pump();
+      const continuePumping = (): void => {
+        void pump().catch((error: unknown) => {
+          releaseReader();
+          if (!cancelled) controller.error(error);
+        });
+      };
+
+      continuePumping();
     },
     async cancel(reason): Promise<void> {
       cancelled = true;


### PR DESCRIPTION
### Motivation

- Prevent unbounded recursion and resource leaks when handling streaming SSE readers and ensure readers are released on error or cancellation.
- Avoid unbounded memory growth for debug logs and usage events by bounding in-memory buffers.
- Allow aborting in-progress admin API tests and ensure runtime credential state is flushed cleanly on shutdown without duplicating signal handlers.

### Description

- Replace recursive `pump()` awaits in multiple proxy SSE stream handlers (`anthropic.ts`, `codebuddy.ts`, `responses.ts`) with an iterative `continuePumping()` pattern that catches errors, releases readers, and reports controller errors.
- Add an `AbortController` (`apiTestAbortControllerRef`) to the admin UI (`app/page-shell.tsx`) to abort previous API tests and wire `signal` into the `fetch` request and cleanup on unmount. Also wrap streaming reader processing in `try/finally` and call `reader.releaseLock()` on completion.
- Introduce buffer caps `MAX_BUFFERED_LOGS` and `MAX_BUFFERED_EVENTS` and trim `pendingDebugLogs` / `pendingUsageEvents` to the last N entries to bound memory usage (`lib/server/domain/debug.ts`, `lib/server/domain/usage.ts`).
- Improve response snapshot reading to `await reader.cancel()` and always `reader.releaseLock()` in `readSnapshotText`, and ensure `cancel()` handlers release locks (`lib/server/domain/debug.ts`).
- Make credential-model refresh idempotent by storing the refresh promise in a global state and clearing it on completion using `finally` to allow re-entrancy (`lib/server/domain/credential-models.ts`).
- Install shutdown handlers safely by tracking installed signal handlers in global state and removing previous handlers before registering new ones to avoid duplicate listeners (`lib/server/domain/credentials.ts`).

### Testing

- Ran a TypeScript build with `yarn build` which completed successfully.
- Ran linting with `yarn lint` which reported no new issues.
- Executed the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69bd116e1c8325aa8ead5d34304fc8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/orangeboychen/codebuddy2api/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->