### PR TITLE
fix: ignore JavaScript partials in Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,10 @@
+parsers:
+  javascript:
+    # Vitest enforces branch coverage separately. Do not count partial
+    # branches a second time as uncovered lines in the project status.
+    enable_partials: false
+
 coverage:
-  parsers:
-    javascript:
-      # Vitest enforces branch coverage separately. Do not count partial
-      # branches a second time as uncovered lines in the project status.
-      enable_partials: false
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 coverage:
+  parsers:
+    javascript:
+      # Vitest enforces branch coverage separately. Do not count partial
+      # branches a second time as uncovered lines in the project status.
+      enable_partials: false
   status:
     project:
       default:


### PR DESCRIPTION
Configures Codecov to exclude JavaScript partial counts from project coverage. Vitest remains the branch-coverage gate; this keeps Codecov's project calculation aligned with the configured line threshold.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/orangeboychen/codebuddy2api/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->