### PR TITLE
fix: count LCOV partials as hits

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
 parsers:
-  javascript:
-    # Vitest enforces branch coverage separately. Do not count partial
-    # branches a second time as uncovered lines in the project status.
-    enable_partials: false
+  lcov:
+    # Vitest uploads LCOV. Keep its branch metric out of Codecov's line gate;
+    # Vitest enforces the branch threshold locally.
+    partials_as_hits: true
 
 coverage:
   status:


### PR DESCRIPTION
Vitest uploads LCOV coverage. Configure Codecov's LCOV parser to treat partial branch records as hits so the Codecov project status measures line coverage, while Vitest continues to enforce the local branch threshold.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/orangeboychen/codebuddy2api/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->