### PR TITLE
fix: bound proxy response memory retention

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -eu
+
+bun run lint
+bun run format:check
+bun run typecheck
+bun run test:ci
+
+base_sha="$(git merge-base HEAD origin/main)"
+bun run test:patch-branches --base "$base_sha"
+bun run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,5 +29,6 @@
 ## Verification Before PR
 
 - Run `bun run test:ci` to generate `coverage/lcov.info` and `test-report.junit.xml`.
+- Run `bun run test:patch-branches --base "$(git merge-base HEAD origin/main)"` after coverage; changed branch coverage must be at least 90%.
 - Confirm Codecov's `patch` status is successful and meets the target configured in `codecov.yml`; do not lower the patch target or threshold to bypass a coverage failure.
 - Use the Codecov PR report as the source of truth for patch coverage because it compares the uploaded `lcov.info` against the PR base commit.

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -852,28 +852,32 @@ const mapOpenAIStreamToAnthropicSSE = (
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await upstreamReader.read();
+        while (true) {
+          const { done, value } = await upstreamReader.read();
 
-        if (cancelled) {
-          return;
-        }
-
-        if (done) {
-          if (buffer.trim()) {
-            flushFrames([buffer]);
+          if (cancelled) {
+            return;
           }
 
-          finalize();
-          releaseReader();
-          controller.close();
-          return;
-        }
+          if (done) {
+            if (buffer.trim()) {
+              flushFrames([buffer]);
+            }
 
-        buffer += decoder.decode(value, { stream: true });
-        const frames = buffer.split('\n\n');
-        buffer = frames.pop() ?? '';
-        flushFrames(frames);
-        await pump();
+            finalize();
+            releaseReader();
+            controller.close();
+            return;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.length > 1_000_000) {
+            buffer = buffer.slice(-1_000_000);
+          }
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+          flushFrames(frames);
+        }
       };
 
       void pump();

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -85,6 +85,10 @@ interface OpenAIChatChoice {
   finish_reason?: string | null;
 }
 
+interface OpenAIStreamError {
+  error?: { message?: string };
+}
+
 interface OpenAIUsage {
   prompt_tokens?: number;
   completion_tokens?: number;
@@ -817,6 +821,7 @@ const mapOpenAIStreamToAnthropicSSE = (
 
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let cancelled = false;
+  let streamRejected = false;
   const releaseReader = (): void => {
     reader?.releaseLock();
     reader = null;
@@ -827,11 +832,22 @@ const mapOpenAIStreamToAnthropicSSE = (
       const upstreamReader = upstreamResponse.body!.getReader();
       reader = upstreamReader;
       let buffer = '';
+      const rejectStream = (): void => {
+        streamRejected = true;
+        enqueueEvent({
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'Upstream SSE frame exceeds the maximum size',
+          },
+        });
+      };
 
       const flushFrames = (frames: string[]): void => {
         for (const frame of frames) {
           if (frame.length > MAX_STREAM_FRAME_LENGTH) {
-            continue;
+            rejectStream();
+            return;
           }
           const line = frame
             .split('\n')
@@ -849,6 +865,11 @@ const mapOpenAIStreamToAnthropicSSE = (
 
           try {
             const chunk = JSON.parse(raw) as OpenAIStreamChunk;
+            const upstreamError = chunk as OpenAIStreamError;
+            if (upstreamError.error?.message) {
+              rejectStream();
+              return;
+            }
             processChunk(chunk);
           } catch {
             // Skip unparseable frames
@@ -868,8 +889,9 @@ const mapOpenAIStreamToAnthropicSSE = (
             if (buffer.trim()) {
               flushFrames([buffer]);
             }
-
-            finalize();
+            if (!streamRejected) {
+              finalize();
+            }
             releaseReader();
             controller.close();
             return;
@@ -879,9 +901,19 @@ const mapOpenAIStreamToAnthropicSSE = (
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
           if (buffer.length > MAX_STREAM_FRAME_LENGTH) {
-            buffer = '';
+            rejectStream();
+          } else {
+            flushFrames(frames);
           }
-          flushFrames(frames);
+          if (streamRejected) {
+            try {
+              await reader!.cancel();
+            } finally {
+              releaseReader();
+              controller.close();
+            }
+            return;
+          }
         }
       };
 

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -875,7 +875,7 @@ const mapOpenAIStreamToAnthropicSSE = (
             buffer = buffer.slice(-1_000_000);
           }
           const frames = buffer.split('\n\n');
-          buffer = frames.pop() ?? '';
+          buffer = frames.pop()!;
           flushFrames(frames);
         }
       };

--- a/lib/server/proxy/anthropic.ts
+++ b/lib/server/proxy/anthropic.ts
@@ -5,6 +5,8 @@ import type { DebugTrace } from '../domain/debug';
 
 import { proxyChatCompletions, type ChatRequestBody } from './codebuddy';
 
+const MAX_STREAM_FRAME_LENGTH = 1_000_000;
+
 // ---------------------------------------------------------------------------
 // Anthropic Messages API types
 // ---------------------------------------------------------------------------
@@ -828,6 +830,9 @@ const mapOpenAIStreamToAnthropicSSE = (
 
       const flushFrames = (frames: string[]): void => {
         for (const frame of frames) {
+          if (frame.length > MAX_STREAM_FRAME_LENGTH) {
+            continue;
+          }
           const line = frame
             .split('\n')
             .find((segment) => segment.startsWith('data: '));
@@ -871,11 +876,11 @@ const mapOpenAIStreamToAnthropicSSE = (
           }
 
           buffer += decoder.decode(value, { stream: true });
-          if (buffer.length > 1_000_000) {
-            buffer = buffer.slice(-1_000_000);
-          }
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
+          if (buffer.length > MAX_STREAM_FRAME_LENGTH) {
+            buffer = '';
+          }
           flushFrames(frames);
         }
       };

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -287,7 +287,7 @@ const trackResponsesUsageStream = async ({
             buffer = buffer.slice(-1_000_000);
           }
           const frames = buffer.split('\n\n');
-          buffer = frames.pop() ?? '';
+          buffer = frames.pop()!;
 
           frames.forEach((frame) => {
             inspectFrame(frame);
@@ -987,7 +987,7 @@ const normalizeStreamingResponse = ({
             buffer = buffer.slice(-1_000_000);
           }
           const frames = buffer.split('\n\n');
-          buffer = frames.pop() ?? '';
+          buffer = frames.pop()!;
           flushFrames(frames);
         }
       };

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -985,7 +985,11 @@ const normalizeStreamingResponse = ({
             });
 
             releaseReader();
-            controller.close();
+            try {
+              controller.close();
+            } catch {
+              // The downstream stream may have been cancelled while the pump was completing.
+            }
             return;
           }
 

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -958,6 +958,11 @@ const normalizeStreamingResponse = ({
       const flushFrames = (frames: string[]): void => {
         frames.forEach((frame) => {
           if (frame.length > MAX_STREAM_FRAME_LENGTH) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"error":{"message":"Upstream SSE frame exceeds the maximum size"}}\n\n',
+              ),
+            );
             return;
           }
           controller.enqueue(encoder.encode(`${processFrame(frame)}\n\n`));
@@ -997,7 +1002,18 @@ const normalizeStreamingResponse = ({
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
           if (buffer.length > MAX_STREAM_FRAME_LENGTH) {
-            buffer = '';
+            controller.enqueue(
+              encoder.encode(
+                'data: {"error":{"message":"Upstream SSE frame exceeds the maximum size"}}\n\n',
+              ),
+            );
+            try {
+              await reader!.cancel();
+            } finally {
+              releaseReader();
+              controller.close();
+            }
+            return;
           }
           flushFrames(frames);
         }

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -257,40 +257,43 @@ const trackResponsesUsageStream = async ({
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await upstreamReader.read();
+        while (true) {
+          const { done, value } = await upstreamReader.read();
 
-        if (cancelled) {
-          return;
-        }
-
-        if (done) {
-          if (buffer) {
-            inspectFrame(buffer);
-            controller.enqueue(encoder.encode(buffer));
+          if (cancelled) {
+            return;
           }
 
-          await recordProxyUsage({
-            model,
-            proxyContext,
-            route: '/v1/responses',
-            usage: latestUsage,
+          if (done) {
+            if (buffer) {
+              inspectFrame(buffer);
+              controller.enqueue(encoder.encode(buffer));
+            }
+
+            await recordProxyUsage({
+              model,
+              proxyContext,
+              route: '/v1/responses',
+              usage: latestUsage,
+            });
+            releaseReader();
+            controller.close();
+            return;
+          }
+
+          const text = decoder.decode(value, { stream: true });
+          buffer += text;
+          if (buffer.length > 1_000_000) {
+            buffer = buffer.slice(-1_000_000);
+          }
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+
+          frames.forEach((frame) => {
+            inspectFrame(frame);
+            controller.enqueue(encoder.encode(`${frame}\n\n`));
           });
-          releaseReader();
-          controller.close();
-          return;
         }
-
-        const text = decoder.decode(value, { stream: true });
-        buffer += text;
-        const frames = buffer.split('\n\n');
-        buffer = frames.pop() ?? '';
-
-        frames.forEach((frame) => {
-          inspectFrame(frame);
-          controller.enqueue(encoder.encode(`${frame}\n\n`));
-        });
-
-        await pump();
       };
 
       void pump();
@@ -955,34 +958,38 @@ const normalizeStreamingResponse = ({
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await upstreamReader.read();
+        while (true) {
+          const { done, value } = await upstreamReader.read();
 
-        if (cancelled) {
-          return;
-        }
-
-        if (done) {
-          if (buffer.trim()) {
-            flushFrames([buffer]);
+          if (cancelled) {
+            return;
           }
 
-          await recordProxyUsage({
-            model,
-            proxyContext,
-            route,
-            usage: latestUsage,
-          });
+          if (done) {
+            if (buffer.trim()) {
+              flushFrames([buffer]);
+            }
 
-          releaseReader();
-          controller.close();
-          return;
+            await recordProxyUsage({
+              model,
+              proxyContext,
+              route,
+              usage: latestUsage,
+            });
+
+            releaseReader();
+            controller.close();
+            return;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.length > 1_000_000) {
+            buffer = buffer.slice(-1_000_000);
+          }
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+          flushFrames(frames);
         }
-
-        buffer += decoder.decode(value, { stream: true });
-        const frames = buffer.split('\n\n');
-        buffer = frames.pop() ?? '';
-        flushFrames(frames);
-        await pump();
       };
 
       void pump();

--- a/lib/server/proxy/codebuddy.ts
+++ b/lib/server/proxy/codebuddy.ts
@@ -36,6 +36,7 @@ interface CacheableTextBlock {
 }
 
 const MIN_AUTO_CACHE_TEXT_LENGTH = 1024;
+const MAX_STREAM_FRAME_LENGTH = 1_000_000;
 
 export interface ChatRequestBody {
   model?: string;
@@ -283,13 +284,16 @@ const trackResponsesUsageStream = async ({
 
           const text = decoder.decode(value, { stream: true });
           buffer += text;
-          if (buffer.length > 1_000_000) {
-            buffer = buffer.slice(-1_000_000);
-          }
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
+          if (buffer.length > MAX_STREAM_FRAME_LENGTH) {
+            buffer = '';
+          }
 
           frames.forEach((frame) => {
+            if (frame.length > MAX_STREAM_FRAME_LENGTH) {
+              return;
+            }
             inspectFrame(frame);
             controller.enqueue(encoder.encode(`${frame}\n\n`));
           });
@@ -953,6 +957,9 @@ const normalizeStreamingResponse = ({
 
       const flushFrames = (frames: string[]): void => {
         frames.forEach((frame) => {
+          if (frame.length > MAX_STREAM_FRAME_LENGTH) {
+            return;
+          }
           controller.enqueue(encoder.encode(`${processFrame(frame)}\n\n`));
         });
       };
@@ -983,11 +990,11 @@ const normalizeStreamingResponse = ({
           }
 
           buffer += decoder.decode(value, { stream: true });
-          if (buffer.length > 1_000_000) {
-            buffer = buffer.slice(-1_000_000);
-          }
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
+          if (buffer.length > MAX_STREAM_FRAME_LENGTH) {
+            buffer = '';
+          }
           flushFrames(frames);
         }
       };

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -1031,8 +1031,8 @@ const createResponsesEventStream = async (
   transcript: TranscriptMessage[],
   model: string,
   previousResponseId: string | null,
-  maxOutputTokens?: number,
-  proxyContext?: ProxyContext,
+  maxOutputTokens: number | undefined,
+  proxyContext: ProxyContext,
   debugTrace?: DebugTrace,
 ): Promise<Response> => {
   const upstreamResponse = await proxyChatCompletions(
@@ -1211,8 +1211,8 @@ const createResponsesEventStream = async (
                 defaults.tools,
               );
             await storeResponseSession({
-              accessKeyId: proxyContext?.accessKeyId ?? null,
-              credentialFilename: proxyContext?.credentialFilename ?? null,
+              accessKeyId: proxyContext.accessKeyId,
+              credentialFilename: proxyContext.credentialFilename,
               createdAt: Date.now(),
               id: responseId,
               model,
@@ -1306,7 +1306,7 @@ const createResponsesEventStream = async (
             buffer = buffer.slice(-MAX_STREAM_BUFFER_LENGTH);
           }
           const frames = buffer.split('\n\n');
-          buffer = frames.pop() ?? '';
+          buffer = frames.pop()!;
 
           frames.forEach((frame) => {
             const line = frame

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -15,6 +15,7 @@ import { createErrorResponse } from '../shared/http';
 import {
   deleteStorageJson,
   getStorageBackendMeta,
+  listStorageJson,
   readStorageJson,
   writeStorageJson,
 } from '../storage';
@@ -134,6 +135,8 @@ const MAX_TOOL_ARGUMENT_LENGTH = 1_000_000;
 
 const globalResponsesState = globalThis as typeof globalThis & {
   __codebuddy2apiResponseSessions__?: Map<string, ResponseSession>;
+  __codebuddy2apiResponseSessionBytes__?: Map<string, number>;
+  __codebuddy2apiResponseSessionTotalBytes__?: number;
 };
 
 const getSessionStore = (): Map<string, ResponseSession> => {
@@ -144,36 +147,87 @@ const getSessionStore = (): Map<string, ResponseSession> => {
   return globalResponsesState.__codebuddy2apiResponseSessions__;
 };
 
+const getSessionByteStore = (): Map<string, number> => {
+  if (!globalResponsesState.__codebuddy2apiResponseSessionBytes__) {
+    globalResponsesState.__codebuddy2apiResponseSessionBytes__ = new Map();
+  }
+
+  return globalResponsesState.__codebuddy2apiResponseSessionBytes__;
+};
+
+const getSessionTotalBytes = (): number => {
+  return globalResponsesState.__codebuddy2apiResponseSessionTotalBytes__ ?? 0;
+};
+
+const setSessionTotalBytes = (value: number): void => {
+  globalResponsesState.__codebuddy2apiResponseSessionTotalBytes__ = value;
+};
+
+const removeLocalResponseSession = (id: string): void => {
+  const byteStore = getSessionByteStore();
+  const store = getSessionStore();
+  const bytes = byteStore.get(id) ?? 0;
+  store.delete(id);
+  byteStore.delete(id);
+  setSessionTotalBytes(Math.max(0, getSessionTotalBytes() - bytes));
+};
+
 const pruneResponseSessions = (): void => {
   const store = getSessionStore();
   const expiresBefore = Date.now() - RESPONSE_SESSION_TTL_MS;
 
   for (const [id, session] of store) {
     if (session.createdAt <= expiresBefore) {
-      store.delete(id);
+      removeLocalResponseSession(id);
     }
   }
-
-  const getStoreBytes = (): number => {
-    let bytes = 0;
-    for (const session of store.values()) {
-      bytes += Buffer.byteLength(JSON.stringify(session), 'utf8');
-    }
-    return bytes;
-  };
 
   while (
     store.size > MAX_RESPONSE_SESSIONS ||
-    getStoreBytes() > MAX_RESPONSE_SESSION_TOTAL_BYTES
+    getSessionTotalBytes() > MAX_RESPONSE_SESSION_TOTAL_BYTES
   ) {
     const oldestId = store.keys().next().value;
-
-    if (!oldestId) {
-      return;
-    }
-
-    store.delete(oldestId);
+    removeLocalResponseSession(oldestId!);
   }
+};
+
+const prunePgResponseSessions = async (): Promise<void> => {
+  const documents = await listStorageJson<ResponseSession>(
+    RESPONSE_SESSION_NAMESPACE,
+  );
+  const expiresBefore = Date.now() - RESPONSE_SESSION_TTL_MS;
+  const candidates = documents
+    .map((document) => ({
+      bytes: Buffer.byteLength(JSON.stringify(document.value), 'utf8'),
+      createdAt: document.value.createdAt,
+      key: document.key,
+    }))
+    .sort((left, right) => left.createdAt - right.createdAt);
+  let totalBytes = candidates.reduce(
+    (total, candidate) => total + candidate.bytes,
+    0,
+  );
+  const toDelete = candidates.filter(
+    (candidate) => candidate.createdAt <= expiresBefore,
+  );
+  const remaining = candidates.filter(
+    (candidate) => candidate.createdAt > expiresBefore,
+  );
+
+  while (
+    remaining.length > MAX_RESPONSE_SESSIONS ||
+    totalBytes > MAX_RESPONSE_SESSION_TOTAL_BYTES
+  ) {
+    const candidate = remaining.shift();
+    toDelete.push(candidate!);
+    totalBytes -= candidate!.bytes;
+  }
+
+  await Promise.all(
+    toDelete.map((candidate) =>
+      deleteStorageJson(RESPONSE_SESSION_NAMESPACE, candidate.key),
+    ),
+  );
 };
 
 const isPgResponseSessionStore = (): boolean => {
@@ -224,16 +278,26 @@ const storeResponseSession = async (
 ): Promise<void> => {
   const serialized = JSON.stringify(session);
   if (Buffer.byteLength(serialized, 'utf8') > MAX_RESPONSE_SESSION_BYTES) {
-    return;
+    throw new Error('Response session exceeds the maximum size');
   }
 
   if (isPgResponseSessionStore()) {
     await writeStorageJson(RESPONSE_SESSION_NAMESPACE, session.id, session);
+    try {
+      await prunePgResponseSessions();
+    } catch (error) {
+      console.warn('[CodeBuddy2API] Unable to prune Responses sessions', error);
+    }
     return;
   }
 
   const store = getSessionStore();
+  const byteStore = getSessionByteStore();
+  const previousBytes = byteStore.get(session.id) ?? 0;
+  const sessionBytes = Buffer.byteLength(serialized, 'utf8');
   store.set(session.id, session);
+  byteStore.set(session.id, sessionBytes);
+  setSessionTotalBytes(getSessionTotalBytes() - previousBytes + sessionBytes);
   pruneResponseSessions();
 };
 
@@ -864,11 +928,12 @@ const prepareTranscript = async (
     previousSession ??
     (await getValidatedPreviousSession(previousResponseId, accessKeyId));
 
-  const transcript = [
-    ...(resolvedPreviousSession?.transcript ?? []).slice(
-      -MAX_RESPONSE_TRANSCRIPT_MESSAGES,
-    ),
-  ];
+  const transcript = (resolvedPreviousSession?.transcript ?? []).slice(
+    -MAX_RESPONSE_TRANSCRIPT_MESSAGES,
+  );
+  while (transcript[0]?.role === 'tool') {
+    transcript.shift();
+  }
   const model =
     typeof body.model === 'string' && body.model.trim()
       ? body.model
@@ -1086,6 +1151,7 @@ const createResponsesEventStream = async (
       const upstreamReader = upstreamResponse.body!.getReader();
       reader = upstreamReader;
       let buffer = '';
+      let streamRejected = false;
 
       const enqueueEvent = (payload: Record<string, unknown>): void => {
         const eventType =
@@ -1210,27 +1276,42 @@ const createResponsesEventStream = async (
                 [...toolCallStates.values()],
                 defaults.tools,
               );
-            await storeResponseSession({
-              accessKeyId: proxyContext.accessKeyId,
-              credentialFilename: proxyContext.credentialFilename,
-              createdAt: Date.now(),
-              id: responseId,
-              model,
-              transcript: [
-                ...transcript,
-                {
-                  role: 'assistant',
-                  content: getAssistantTranscriptContent(
-                    outputText,
-                    transcriptToolCalls,
-                  ),
-                  ...(transcriptToolCalls
-                    ? { tool_calls: transcriptToolCalls }
-                    : {}),
-                },
-              ],
-              defaults,
-            });
+            try {
+              await storeResponseSession({
+                accessKeyId: proxyContext.accessKeyId,
+                credentialFilename: proxyContext.credentialFilename,
+                createdAt: Date.now(),
+                id: responseId,
+                model,
+                transcript: [
+                  ...transcript,
+                  {
+                    role: 'assistant',
+                    content: getAssistantTranscriptContent(
+                      outputText,
+                      transcriptToolCalls,
+                    ),
+                    ...(transcriptToolCalls
+                      ? { tool_calls: transcriptToolCalls }
+                      : {}),
+                  },
+                ],
+                defaults,
+              });
+            } catch (error) {
+              console.error(
+                '[CodeBuddy2API] Failed to persist Responses session',
+                error,
+              );
+              enqueueEvent({
+                type: 'response.error',
+                error: { message: 'Failed to persist response session' },
+              });
+              controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+              releaseReader();
+              controller.close();
+              return;
+            }
             [...toolCallStates.values()].forEach((toolCallState) => {
               maybeEmitToolCallAdded(toolCallState, true);
               enqueueEvent({
@@ -1302,13 +1383,16 @@ const createResponsesEventStream = async (
           }
 
           buffer += decoder.decode(value, { stream: true });
-          if (buffer.length > MAX_STREAM_BUFFER_LENGTH) {
-            buffer = buffer.slice(-MAX_STREAM_BUFFER_LENGTH);
-          }
           const frames = buffer.split('\n\n');
           buffer = frames.pop()!;
+          if (buffer.length > MAX_STREAM_BUFFER_LENGTH) {
+            buffer = '';
+          }
 
           frames.forEach((frame) => {
+            if (frame.length > MAX_STREAM_BUFFER_LENGTH) {
+              return;
+            }
             const line = frame
               .split('\n')
               .find((segment) => segment.startsWith('data: '));
@@ -1337,9 +1421,10 @@ const createResponsesEventStream = async (
 
               if (delta?.content) {
                 ensureMessageAdded();
-                outputText = `${outputText}${delta.content}`.slice(
-                  -MAX_STREAM_TEXT_LENGTH,
-                );
+                outputText = `${outputText}${delta.content}`;
+                if (outputText.length > MAX_STREAM_TEXT_LENGTH) {
+                  throw new Error('Response output exceeds the maximum size');
+                }
                 enqueueEvent({
                   type: 'response.output_text.delta',
                   delta: delta.content,
@@ -1388,10 +1473,16 @@ const createResponsesEventStream = async (
                 maybeEmitToolCallAdded(current);
 
                 if (toolCall.function?.arguments) {
-                  current.arguments =
-                    `${current.arguments}${toolCall.function.arguments}`.slice(
-                      -MAX_TOOL_ARGUMENT_LENGTH,
+                  if (
+                    current.arguments.length +
+                      toolCall.function.arguments.length >
+                    MAX_TOOL_ARGUMENT_LENGTH
+                  ) {
+                    throw new Error(
+                      'Response tool arguments exceed the maximum size',
                     );
+                  }
+                  current.arguments = `${current.arguments}${toolCall.function.arguments}`;
                   if (current.addedEmitted) {
                     enqueueEvent({
                       type: getResponsesToolCallArgumentDeltaEventType(
@@ -1405,9 +1496,7 @@ const createResponsesEventStream = async (
                     });
                   } else {
                     current.pendingArgumentDeltas.push(
-                      toolCall.function.arguments.slice(
-                        -MAX_TOOL_ARGUMENT_LENGTH,
-                      ),
+                      toolCall.function.arguments,
                     );
                   }
                 }
@@ -1417,7 +1506,13 @@ const createResponsesEventStream = async (
                   toolCallStateKeys.set(key, current.canonicalKey);
                 });
               });
-            } catch {
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                error.message.includes('exceed the maximum size')
+              ) {
+                streamRejected = true;
+              }
               console.error(
                 '[CodeBuddy2API] Failed to parse upstream SSE frame',
                 {
@@ -1433,6 +1528,12 @@ const createResponsesEventStream = async (
               });
             }
           });
+
+          if (streamRejected) {
+            releaseReader();
+            controller.close();
+            return;
+          }
         }
       };
 
@@ -1616,7 +1717,10 @@ export const handleResponsesRequest = async (
     return createErrorResponse(
       error instanceof Error && error.message.includes('previous_response_id')
         ? 400
-        : 500,
+        : error instanceof Error &&
+            error.message.includes('Response session exceeds')
+          ? 413
+          : 500,
       error instanceof Error ? error.message : 'Unexpected responses error',
     );
   }

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -132,6 +132,7 @@ const RESPONSE_SESSION_NAMESPACE = 'responses';
 const MAX_STREAM_BUFFER_LENGTH = 1_000_000;
 const MAX_STREAM_TEXT_LENGTH = 2_000_000;
 const MAX_TOOL_ARGUMENT_LENGTH = 1_000_000;
+const MAX_TOOL_NAME_LENGTH = 256;
 
 const globalResponsesState = globalThis as typeof globalThis & {
   __codebuddy2apiResponseSessions__?: Map<string, ResponseSession>;
@@ -1390,22 +1391,25 @@ const createResponsesEventStream = async (
             buffer = '';
           }
 
-          frames.forEach((frame) => {
+          for (const frame of frames) {
+            if (streamRejected) {
+              break;
+            }
             if (frame.length > MAX_STREAM_BUFFER_LENGTH) {
-              return;
+              continue;
             }
             const line = frame
               .split('\n')
               .find((segment) => segment.startsWith('data: '));
 
             if (!line) {
-              return;
+              continue;
             }
 
             const raw = line.slice(6).trim();
 
             if (!raw || raw === '[DONE]') {
-              return;
+              continue;
             }
 
             try {
@@ -1469,6 +1473,14 @@ const createResponsesEventStream = async (
                 };
 
                 if (toolCall.function?.name) {
+                  if (
+                    current.name.length + toolCall.function.name.length >
+                    MAX_TOOL_NAME_LENGTH
+                  ) {
+                    throw new Error(
+                      'Response tool name exceeds the maximum size',
+                    );
+                  }
                   current.name += toolCall.function.name;
                 }
                 maybeEmitToolCallAdded(current);
@@ -1520,7 +1532,7 @@ const createResponsesEventStream = async (
             } catch (error) {
               if (
                 error instanceof Error &&
-                error.message.includes('exceed the maximum size')
+                error.message.includes('maximum size')
               ) {
                 streamRejected = true;
               }
@@ -1538,7 +1550,7 @@ const createResponsesEventStream = async (
                 },
               });
             }
-          });
+          }
 
           if (streamRejected) {
             try {

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -12,6 +12,12 @@ import {
 } from './codebuddy';
 import { resolveRequestAccessKey } from './auth';
 import { createErrorResponse } from '../shared/http';
+import {
+  deleteStorageJson,
+  getStorageBackendMeta,
+  readStorageJson,
+  writeStorageJson,
+} from '../storage';
 
 interface ResponsesInputItem {
   type?: string;
@@ -118,6 +124,13 @@ const CUSTOM_TOOL_INPUT_DESCRIPTION =
   'Raw string input for the original custom tool.';
 const MAX_RESPONSE_SESSIONS = 1_000;
 const RESPONSE_SESSION_TTL_MS = 60 * 60 * 1000;
+const MAX_RESPONSE_SESSION_BYTES = 8 * 1024 * 1024;
+const MAX_RESPONSE_SESSION_TOTAL_BYTES = 64 * 1024 * 1024;
+const MAX_RESPONSE_TRANSCRIPT_MESSAGES = 200;
+const RESPONSE_SESSION_NAMESPACE = 'responses';
+const MAX_STREAM_BUFFER_LENGTH = 1_000_000;
+const MAX_STREAM_TEXT_LENGTH = 2_000_000;
+const MAX_TOOL_ARGUMENT_LENGTH = 1_000_000;
 
 const globalResponsesState = globalThis as typeof globalThis & {
   __codebuddy2apiResponseSessions__?: Map<string, ResponseSession>;
@@ -141,7 +154,18 @@ const pruneResponseSessions = (): void => {
     }
   }
 
-  while (store.size > MAX_RESPONSE_SESSIONS) {
+  const getStoreBytes = (): number => {
+    let bytes = 0;
+    for (const session of store.values()) {
+      bytes += Buffer.byteLength(JSON.stringify(session), 'utf8');
+    }
+    return bytes;
+  };
+
+  while (
+    store.size > MAX_RESPONSE_SESSIONS ||
+    getStoreBytes() > MAX_RESPONSE_SESSION_TOTAL_BYTES
+  ) {
     const oldestId = store.keys().next().value;
 
     if (!oldestId) {
@@ -152,17 +176,37 @@ const pruneResponseSessions = (): void => {
   }
 };
 
-const getResponseSession = (id: string): ResponseSession | undefined => {
+const isPgResponseSessionStore = (): boolean => {
+  return getStorageBackendMeta().backend === 'pg';
+};
+
+const getResponseSession = async (
+  id: string,
+): Promise<ResponseSession | undefined> => {
+  if (isPgResponseSessionStore()) {
+    const session = await readStorageJson<ResponseSession>(
+      RESPONSE_SESSION_NAMESPACE,
+      id,
+    );
+    if (!session || session.createdAt <= Date.now() - RESPONSE_SESSION_TTL_MS) {
+      if (session) {
+        await deleteStorageJson(RESPONSE_SESSION_NAMESPACE, id);
+      }
+      return undefined;
+    }
+    return session;
+  }
+
   pruneResponseSessions();
   return getSessionStore().get(id);
 };
 
-const getValidatedPreviousSession = (
+const getValidatedPreviousSession = async (
   previousResponseId: string | null,
   accessKeyId: string | null,
-): ResponseSession | undefined => {
+): Promise<ResponseSession | undefined> => {
   const previousSession = previousResponseId
-    ? getResponseSession(previousResponseId)
+    ? await getResponseSession(previousResponseId)
     : undefined;
 
   if (
@@ -175,7 +219,19 @@ const getValidatedPreviousSession = (
   return previousSession;
 };
 
-const storeResponseSession = (session: ResponseSession): void => {
+const storeResponseSession = async (
+  session: ResponseSession,
+): Promise<void> => {
+  const serialized = JSON.stringify(session);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_RESPONSE_SESSION_BYTES) {
+    return;
+  }
+
+  if (isPgResponseSessionStore()) {
+    await writeStorageJson(RESPONSE_SESSION_NAMESPACE, session.id, session);
+    return;
+  }
+
   const store = getSessionStore();
   store.set(session.id, session);
   pruneResponseSessions();
@@ -806,9 +862,13 @@ const prepareTranscript = async (
   const previousResponseId = body.previous_response_id ?? null;
   const resolvedPreviousSession =
     previousSession ??
-    getValidatedPreviousSession(previousResponseId, accessKeyId);
+    (await getValidatedPreviousSession(previousResponseId, accessKeyId));
 
-  const transcript = [...(resolvedPreviousSession?.transcript ?? [])];
+  const transcript = [
+    ...(resolvedPreviousSession?.transcript ?? []).slice(
+      -MAX_RESPONSE_TRANSCRIPT_MESSAGES,
+    ),
+  ];
   const model =
     typeof body.model === 'string' && body.model.trim()
       ? body.model
@@ -879,7 +939,7 @@ const normalizeTranscriptMessageToolNames = (
   });
 };
 
-const mapChatResponseToResponsesPayload = (
+const mapChatResponseToResponsesPayload = async (
   accessKeyId: string | null,
   credentialFilename: string | null,
   defaults: ResponseSessionDefaults,
@@ -887,7 +947,7 @@ const mapChatResponseToResponsesPayload = (
   model: string,
   previousResponseId: string | null,
   upstreamPayload: Record<string, unknown>,
-): Record<string, unknown> => {
+): Promise<Record<string, unknown>> => {
   const responseId = createResponseId();
   const choices = Array.isArray(upstreamPayload.choices)
     ? upstreamPayload.choices
@@ -934,7 +994,7 @@ const mapChatResponseToResponsesPayload = (
     );
   });
 
-  storeResponseSession({
+  await storeResponseSession({
     accessKeyId,
     credentialFilename,
     createdAt: Date.now(),
@@ -1137,231 +1197,243 @@ const createResponsesEventStream = async (
       };
 
       const pump = async (): Promise<void> => {
-        const { done, value } = await upstreamReader.read();
+        while (true) {
+          const { done, value } = await upstreamReader.read();
 
-        if (cancelled) {
-          return;
-        }
+          if (cancelled) {
+            return;
+          }
 
-        if (done) {
-          const transcriptToolCalls =
-            buildStreamingAssistantTranscriptToolCalls(
-              [...toolCallStates.values()],
-              defaults.tools,
-            );
-          storeResponseSession({
-            accessKeyId: proxyContext?.accessKeyId ?? null,
-            credentialFilename: proxyContext?.credentialFilename ?? null,
-            createdAt: Date.now(),
-            id: responseId,
-            model,
-            transcript: [
-              ...transcript,
-              {
-                role: 'assistant',
-                content: getAssistantTranscriptContent(
-                  outputText,
-                  transcriptToolCalls,
-                ),
-                ...(transcriptToolCalls
-                  ? { tool_calls: transcriptToolCalls }
-                  : {}),
-              },
-            ],
-            defaults,
-          });
-          [...toolCallStates.values()].forEach((toolCallState) => {
-            maybeEmitToolCallAdded(toolCallState, true);
-            enqueueEvent({
-              type: 'response.output_item.done',
-              item: buildResponsesToolCallOutputItem(defaults.tools, {
-                arguments: toolCallState.arguments,
-                callId: toolCallState.callId,
-                id: toolCallState.outputItemId,
-                name: toolCallState.name || 'function',
-                status: 'completed',
-              }),
-              output_index: toolCallState.outputIndex,
-              response_id: responseId,
-            });
-            enqueueEvent({
-              type: getResponsesToolCallArgumentDeltaEventType(
+          if (done) {
+            const transcriptToolCalls =
+              buildStreamingAssistantTranscriptToolCalls(
+                [...toolCallStates.values()],
                 defaults.tools,
-                toolCallState.name,
-              ).replace('.delta', '.done'),
-              arguments: toolCallState.arguments,
-              item_id: toolCallState.outputItemId,
-              output_index: toolCallState.outputIndex,
-              response_id: responseId,
-            });
-          });
-          if (outputText) {
-            ensureMessageAdded();
-            enqueueEvent({
-              type: 'response.output_text.done',
-              item: buildStreamingMessageItem('completed'),
-              output_index: messageState.outputIndex,
-              response_id: responseId,
-              text: outputText,
-            });
-            enqueueEvent({
-              type: 'response.output_item.done',
-              item: buildStreamingMessageItem('completed'),
-              output_index: messageState.outputIndex,
-              response_id: responseId,
-            });
-          }
-          enqueueEvent({
-            type: 'response.completed',
-            response: {
+              );
+            await storeResponseSession({
+              accessKeyId: proxyContext?.accessKeyId ?? null,
+              credentialFilename: proxyContext?.credentialFilename ?? null,
+              createdAt: Date.now(),
               id: responseId,
-              status: 'completed',
-              output_text: outputText,
-              previous_response_id: previousResponseId,
-              output: [
-                ...(outputText ? [buildStreamingMessageItem('completed')] : []),
-                ...[...toolCallStates.values()].map((toolCallState) =>
-                  buildResponsesToolCallOutputItem(defaults.tools, {
-                    arguments: toolCallState.arguments,
-                    callId: toolCallState.callId,
-                    id: toolCallState.outputItemId,
-                    name: toolCallState.name || 'function',
-                    status: 'completed',
-                  }),
-                ),
+              model,
+              transcript: [
+                ...transcript,
+                {
+                  role: 'assistant',
+                  content: getAssistantTranscriptContent(
+                    outputText,
+                    transcriptToolCalls,
+                  ),
+                  ...(transcriptToolCalls
+                    ? { tool_calls: transcriptToolCalls }
+                    : {}),
+                },
               ],
-            },
-          });
-          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
-          releaseReader();
-          controller.close();
-          return;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const frames = buffer.split('\n\n');
-        buffer = frames.pop() ?? '';
-
-        frames.forEach((frame) => {
-          const line = frame
-            .split('\n')
-            .find((segment) => segment.startsWith('data: '));
-
-          if (!line) {
-            return;
-          }
-
-          const raw = line.slice(6).trim();
-
-          if (!raw || raw === '[DONE]') {
-            return;
-          }
-
-          try {
-            const payload = JSON.parse(raw) as {
-              choices?: Array<{
-                delta?: {
-                  content?: string;
-                  reasoning_content?: string;
-                  tool_calls?: ChatResponseToolCall[];
-                };
-              }>;
-            };
-            const delta = payload.choices?.[0]?.delta;
-
-            if (delta?.content) {
-              ensureMessageAdded();
-              outputText += delta.content;
+              defaults,
+            });
+            [...toolCallStates.values()].forEach((toolCallState) => {
+              maybeEmitToolCallAdded(toolCallState, true);
               enqueueEvent({
-                type: 'response.output_text.delta',
-                delta: delta.content,
-                item: buildStreamingMessageItem('in_progress'),
+                type: 'response.output_item.done',
+                item: buildResponsesToolCallOutputItem(defaults.tools, {
+                  arguments: toolCallState.arguments,
+                  callId: toolCallState.callId,
+                  id: toolCallState.outputItemId,
+                  name: toolCallState.name || 'function',
+                  status: 'completed',
+                }),
+                output_index: toolCallState.outputIndex,
+                response_id: responseId,
+              });
+              enqueueEvent({
+                type: getResponsesToolCallArgumentDeltaEventType(
+                  defaults.tools,
+                  toolCallState.name,
+                ).replace('.delta', '.done'),
+                arguments: toolCallState.arguments,
+                item_id: toolCallState.outputItemId,
+                output_index: toolCallState.outputIndex,
+                response_id: responseId,
+              });
+            });
+            if (outputText) {
+              ensureMessageAdded();
+              enqueueEvent({
+                type: 'response.output_text.done',
+                item: buildStreamingMessageItem('completed'),
+                output_index: messageState.outputIndex,
+                response_id: responseId,
+                text: outputText,
+              });
+              enqueueEvent({
+                type: 'response.output_item.done',
+                item: buildStreamingMessageItem('completed'),
                 output_index: messageState.outputIndex,
                 response_id: responseId,
               });
             }
+            enqueueEvent({
+              type: 'response.completed',
+              response: {
+                id: responseId,
+                status: 'completed',
+                output_text: outputText,
+                previous_response_id: previousResponseId,
+                output: [
+                  ...(outputText
+                    ? [buildStreamingMessageItem('completed')]
+                    : []),
+                  ...[...toolCallStates.values()].map((toolCallState) =>
+                    buildResponsesToolCallOutputItem(defaults.tools, {
+                      arguments: toolCallState.arguments,
+                      callId: toolCallState.callId,
+                      id: toolCallState.outputItemId,
+                      name: toolCallState.name || 'function',
+                      status: 'completed',
+                    }),
+                  ),
+                ],
+              },
+            });
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+            releaseReader();
+            controller.close();
+            return;
+          }
 
-            if (delta?.reasoning_content) {
-              enqueueEvent({
-                type: 'response.reasoning_text.delta',
-                delta: delta.reasoning_content,
-                response_id: responseId,
-              });
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.length > MAX_STREAM_BUFFER_LENGTH) {
+            buffer = buffer.slice(-MAX_STREAM_BUFFER_LENGTH);
+          }
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() ?? '';
+
+          frames.forEach((frame) => {
+            const line = frame
+              .split('\n')
+              .find((segment) => segment.startsWith('data: '));
+
+            if (!line) {
+              return;
             }
 
-            delta?.tool_calls?.forEach((toolCall, position) => {
-              const lookupKeys = getStreamingToolCallLookupKeys(
-                toolCall,
-                position,
-              );
-              const existingCanonicalKey = lookupKeys
-                .map((key) => toolCallStateKeys.get(key) ?? key)
-                .find((key) => toolCallStates.has(key));
-              const canonicalKey =
-                existingCanonicalKey ??
-                getStreamingToolCallCanonicalKey(toolCall, position);
-              const current = toolCallStates.get(canonicalKey) ?? {
-                addedEmitted: false,
-                arguments: '',
-                canonicalKey,
-                callId: normalizeToolCallId(
-                  toolCall.id,
-                  nextToolCallOutputIndex,
-                ),
-                name: '',
-                outputIndex: nextToolCallOutputIndex++,
-                outputItemId: createResponseOutputId(),
-                pendingArgumentDeltas: [],
+            const raw = line.slice(6).trim();
+
+            if (!raw || raw === '[DONE]') {
+              return;
+            }
+
+            try {
+              const payload = JSON.parse(raw) as {
+                choices?: Array<{
+                  delta?: {
+                    content?: string;
+                    reasoning_content?: string;
+                    tool_calls?: ChatResponseToolCall[];
+                  };
+                }>;
               };
+              const delta = payload.choices?.[0]?.delta;
 
-              if (toolCall.function?.name) {
-                current.name += toolCall.function.name;
+              if (delta?.content) {
+                ensureMessageAdded();
+                outputText = `${outputText}${delta.content}`.slice(
+                  -MAX_STREAM_TEXT_LENGTH,
+                );
+                enqueueEvent({
+                  type: 'response.output_text.delta',
+                  delta: delta.content,
+                  item: buildStreamingMessageItem('in_progress'),
+                  output_index: messageState.outputIndex,
+                  response_id: responseId,
+                });
               }
-              maybeEmitToolCallAdded(current);
 
-              if (toolCall.function?.arguments) {
-                current.arguments += toolCall.function.arguments;
-                if (current.addedEmitted) {
-                  enqueueEvent({
-                    type: getResponsesToolCallArgumentDeltaEventType(
-                      defaults.tools,
-                      current.name,
-                    ),
-                    delta: toolCall.function.arguments,
-                    item_id: current.outputItemId,
-                    output_index: current.outputIndex,
-                    response_id: responseId,
-                  });
-                } else {
-                  current.pendingArgumentDeltas.push(
-                    toolCall.function.arguments,
-                  );
+              if (delta?.reasoning_content) {
+                enqueueEvent({
+                  type: 'response.reasoning_text.delta',
+                  delta: delta.reasoning_content,
+                  response_id: responseId,
+                });
+              }
+
+              delta?.tool_calls?.forEach((toolCall, position) => {
+                const lookupKeys = getStreamingToolCallLookupKeys(
+                  toolCall,
+                  position,
+                );
+                const existingCanonicalKey = lookupKeys
+                  .map((key) => toolCallStateKeys.get(key) ?? key)
+                  .find((key) => toolCallStates.has(key));
+                const canonicalKey =
+                  existingCanonicalKey ??
+                  getStreamingToolCallCanonicalKey(toolCall, position);
+                const current = toolCallStates.get(canonicalKey) ?? {
+                  addedEmitted: false,
+                  arguments: '',
+                  canonicalKey,
+                  callId: normalizeToolCallId(
+                    toolCall.id,
+                    nextToolCallOutputIndex,
+                  ),
+                  name: '',
+                  outputIndex: nextToolCallOutputIndex++,
+                  outputItemId: createResponseOutputId(),
+                  pendingArgumentDeltas: [],
+                };
+
+                if (toolCall.function?.name) {
+                  current.name += toolCall.function.name;
                 }
-              }
+                maybeEmitToolCallAdded(current);
 
-              toolCallStates.set(canonicalKey, current);
-              lookupKeys.forEach((key) => {
-                toolCallStateKeys.set(key, current.canonicalKey);
+                if (toolCall.function?.arguments) {
+                  current.arguments =
+                    `${current.arguments}${toolCall.function.arguments}`.slice(
+                      -MAX_TOOL_ARGUMENT_LENGTH,
+                    );
+                  if (current.addedEmitted) {
+                    enqueueEvent({
+                      type: getResponsesToolCallArgumentDeltaEventType(
+                        defaults.tools,
+                        current.name,
+                      ),
+                      delta: toolCall.function.arguments,
+                      item_id: current.outputItemId,
+                      output_index: current.outputIndex,
+                      response_id: responseId,
+                    });
+                  } else {
+                    current.pendingArgumentDeltas.push(
+                      toolCall.function.arguments.slice(
+                        -MAX_TOOL_ARGUMENT_LENGTH,
+                      ),
+                    );
+                  }
+                }
+
+                toolCallStates.set(canonicalKey, current);
+                lookupKeys.forEach((key) => {
+                  toolCallStateKeys.set(key, current.canonicalKey);
+                });
               });
-            });
-          } catch {
-            console.error(
-              '[CodeBuddy2API] Failed to parse upstream SSE frame',
-              {
-                route: '/v1/responses',
-                frame: raw.slice(0, 1000),
-              },
-            );
-            enqueueEvent({
-              type: 'response.error',
-              error: {
-                message: 'Failed to parse upstream SSE frame',
-              },
-            });
-          }
-        });
-
-        await pump();
+            } catch {
+              console.error(
+                '[CodeBuddy2API] Failed to parse upstream SSE frame',
+                {
+                  route: '/v1/responses',
+                  frame: raw.slice(0, 1000),
+                },
+              );
+              enqueueEvent({
+                type: 'response.error',
+                error: {
+                  message: 'Failed to parse upstream SSE frame',
+                },
+              });
+            }
+          });
+        }
       };
 
       void pump();
@@ -1395,7 +1467,7 @@ export const handleResponsesRequest = async (
     const previousResponseId = body.previous_response_id ?? null;
     const accessKey = await resolveRequestAccessKey(request);
     const storedPreviousSession = previousResponseId
-      ? getResponseSession(previousResponseId)
+      ? await getResponseSession(previousResponseId)
       : undefined;
 
     if (
@@ -1456,7 +1528,7 @@ export const handleResponsesRequest = async (
       );
     }
 
-    const previousSession = getValidatedPreviousSession(
+    const previousSession = await getValidatedPreviousSession(
       previousResponseId,
       accessKey?.id ?? null,
     );
@@ -1526,7 +1598,7 @@ export const handleResponsesRequest = async (
     >;
 
     return Response.json(
-      mapChatResponseToResponsesPayload(
+      await mapChatResponseToResponsesPayload(
         proxyContext.accessKeyId,
         proxyContext.credentialFilename,
         prepared.defaults,

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -115,6 +115,11 @@ interface StreamingMessageState {
   outputItemId: string;
 }
 
+interface ResponseSessionMetadata {
+  bytes: number;
+  createdAt: number;
+}
+
 type SupportedResponsesTool = NonNullable<
   ResponsesRequestBody['tools']
 >[number];
@@ -129,6 +134,8 @@ const MAX_RESPONSE_SESSION_BYTES = 8 * 1024 * 1024;
 const MAX_RESPONSE_SESSION_TOTAL_BYTES = 64 * 1024 * 1024;
 const MAX_RESPONSE_TRANSCRIPT_MESSAGES = 200;
 const RESPONSE_SESSION_NAMESPACE = 'responses';
+const RESPONSE_SESSION_INDEX_NAMESPACE = 'response-session-index';
+const RESPONSE_SESSION_INDEX_KEY = 'metadata';
 const MAX_STREAM_BUFFER_LENGTH = 1_000_000;
 const MAX_STREAM_TEXT_LENGTH = 2_000_000;
 const MAX_TOOL_ARGUMENT_LENGTH = 1_000_000;
@@ -192,17 +199,40 @@ const pruneResponseSessions = (): void => {
   }
 };
 
-const prunePgResponseSessions = async (): Promise<void> => {
+const getPgResponseSessionMetadata = async (): Promise<
+  Record<string, ResponseSessionMetadata>
+> => {
+  const metadata = await readStorageJson<
+    Record<string, ResponseSessionMetadata>
+  >(RESPONSE_SESSION_INDEX_NAMESPACE, RESPONSE_SESSION_INDEX_KEY);
+  if (metadata) {
+    return metadata;
+  }
+
   const documents = await listStorageJson<ResponseSession>(
     RESPONSE_SESSION_NAMESPACE,
   );
-  const expiresBefore = Date.now() - RESPONSE_SESSION_TTL_MS;
-  const candidates = documents
-    .map((document) => ({
+  const initializedMetadata: Record<string, ResponseSessionMetadata> = {};
+  for (const document of documents) {
+    initializedMetadata[document.key] = {
       bytes: Buffer.byteLength(JSON.stringify(document.value), 'utf8'),
       createdAt: document.value.createdAt,
-      key: document.key,
-    }))
+    };
+  }
+
+  await writeStorageJson(
+    RESPONSE_SESSION_INDEX_NAMESPACE,
+    RESPONSE_SESSION_INDEX_KEY,
+    initializedMetadata,
+  );
+  return initializedMetadata;
+};
+
+const prunePgResponseSessions = async (): Promise<void> => {
+  const metadata = await getPgResponseSessionMetadata();
+  const expiresBefore = Date.now() - RESPONSE_SESSION_TTL_MS;
+  const candidates = Object.entries(metadata)
+    .map(([key, value]) => ({ key, ...value }))
     .sort((left, right) => left.createdAt - right.createdAt);
   const toDelete = candidates.filter(
     (candidate) => candidate.createdAt <= expiresBefore,
@@ -229,6 +259,12 @@ const prunePgResponseSessions = async (): Promise<void> => {
       deleteStorageJson(RESPONSE_SESSION_NAMESPACE, candidate.key),
     ),
   );
+  toDelete.forEach((candidate) => delete metadata[candidate.key]);
+  await writeStorageJson(
+    RESPONSE_SESSION_INDEX_NAMESPACE,
+    RESPONSE_SESSION_INDEX_KEY,
+    metadata,
+  );
 };
 
 const isPgResponseSessionStore = (): boolean => {
@@ -246,6 +282,13 @@ const getResponseSession = async (
     if (!session || session.createdAt <= Date.now() - RESPONSE_SESSION_TTL_MS) {
       if (session) {
         await deleteStorageJson(RESPONSE_SESSION_NAMESPACE, id);
+        const metadata = await getPgResponseSessionMetadata();
+        delete metadata[id];
+        await writeStorageJson(
+          RESPONSE_SESSION_INDEX_NAMESPACE,
+          RESPONSE_SESSION_INDEX_KEY,
+          metadata,
+        );
       }
       return undefined;
     }
@@ -283,7 +326,17 @@ const storeResponseSession = async (
   }
 
   if (isPgResponseSessionStore()) {
+    const metadata = await getPgResponseSessionMetadata();
     await writeStorageJson(RESPONSE_SESSION_NAMESPACE, session.id, session);
+    metadata[session.id] = {
+      bytes: Buffer.byteLength(serialized, 'utf8'),
+      createdAt: session.createdAt,
+    };
+    await writeStorageJson(
+      RESPONSE_SESSION_INDEX_NAMESPACE,
+      RESPONSE_SESSION_INDEX_KEY,
+      metadata,
+    );
     try {
       await prunePgResponseSessions();
     } catch (error) {

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -203,24 +203,24 @@ const prunePgResponseSessions = async (): Promise<void> => {
       key: document.key,
     }))
     .sort((left, right) => left.createdAt - right.createdAt);
-  let totalBytes = candidates.reduce(
-    (total, candidate) => total + candidate.bytes,
-    0,
-  );
   const toDelete = candidates.filter(
     (candidate) => candidate.createdAt <= expiresBefore,
   );
   const remaining = candidates.filter(
     (candidate) => candidate.createdAt > expiresBefore,
   );
+  let totalBytes = remaining.reduce(
+    (total, candidate) => total + candidate.bytes,
+    0,
+  );
 
   while (
     remaining.length > MAX_RESPONSE_SESSIONS ||
     totalBytes > MAX_RESPONSE_SESSION_TOTAL_BYTES
   ) {
-    const candidate = remaining.shift();
-    toDelete.push(candidate!);
-    totalBytes -= candidate!.bytes;
+    const candidate = remaining.shift()!;
+    toDelete.push(candidate);
+    totalBytes -= candidate.bytes;
   }
 
   await Promise.all(
@@ -1151,6 +1151,7 @@ const createResponsesEventStream = async (
       const upstreamReader = upstreamResponse.body!.getReader();
       reader = upstreamReader;
       let buffer = '';
+      let totalToolArgumentLength = 0;
       let streamRejected = false;
 
       const enqueueEvent = (payload: Record<string, unknown>): void => {
@@ -1482,6 +1483,16 @@ const createResponsesEventStream = async (
                       'Response tool arguments exceed the maximum size',
                     );
                   }
+                  if (
+                    totalToolArgumentLength +
+                      toolCall.function.arguments.length >
+                    MAX_RESPONSE_SESSION_TOTAL_BYTES
+                  ) {
+                    throw new Error(
+                      'Response tool arguments exceed the maximum size',
+                    );
+                  }
+                  totalToolArgumentLength += toolCall.function.arguments.length;
                   current.arguments = `${current.arguments}${toolCall.function.arguments}`;
                   if (current.addedEmitted) {
                     enqueueEvent({
@@ -1530,8 +1541,12 @@ const createResponsesEventStream = async (
           });
 
           if (streamRejected) {
-            releaseReader();
-            controller.close();
+            try {
+              await reader!.cancel();
+            } finally {
+              releaseReader();
+              controller.close();
+            }
             return;
           }
         }
@@ -1728,4 +1743,6 @@ export const handleResponsesRequest = async (
 
 export const resetResponseSessions = (): void => {
   getSessionStore().clear();
+  getSessionByteStore().clear();
+  setSessionTotalBytes(0);
 };

--- a/lib/server/proxy/responses.ts
+++ b/lib/server/proxy/responses.ts
@@ -135,7 +135,6 @@ const MAX_RESPONSE_SESSION_TOTAL_BYTES = 64 * 1024 * 1024;
 const MAX_RESPONSE_TRANSCRIPT_MESSAGES = 200;
 const RESPONSE_SESSION_NAMESPACE = 'responses';
 const RESPONSE_SESSION_INDEX_NAMESPACE = 'response-session-index';
-const RESPONSE_SESSION_INDEX_KEY = 'metadata';
 const MAX_STREAM_BUFFER_LENGTH = 1_000_000;
 const MAX_STREAM_TEXT_LENGTH = 2_000_000;
 const MAX_TOOL_ARGUMENT_LENGTH = 1_000_000;
@@ -199,40 +198,13 @@ const pruneResponseSessions = (): void => {
   }
 };
 
-const getPgResponseSessionMetadata = async (): Promise<
-  Record<string, ResponseSessionMetadata>
-> => {
-  const metadata = await readStorageJson<
-    Record<string, ResponseSessionMetadata>
-  >(RESPONSE_SESSION_INDEX_NAMESPACE, RESPONSE_SESSION_INDEX_KEY);
-  if (metadata) {
-    return metadata;
-  }
-
-  const documents = await listStorageJson<ResponseSession>(
-    RESPONSE_SESSION_NAMESPACE,
-  );
-  const initializedMetadata: Record<string, ResponseSessionMetadata> = {};
-  for (const document of documents) {
-    initializedMetadata[document.key] = {
-      bytes: Buffer.byteLength(JSON.stringify(document.value), 'utf8'),
-      createdAt: document.value.createdAt,
-    };
-  }
-
-  await writeStorageJson(
-    RESPONSE_SESSION_INDEX_NAMESPACE,
-    RESPONSE_SESSION_INDEX_KEY,
-    initializedMetadata,
-  );
-  return initializedMetadata;
-};
-
 const prunePgResponseSessions = async (): Promise<void> => {
-  const metadata = await getPgResponseSessionMetadata();
+  const metadataDocuments = await listStorageJson<ResponseSessionMetadata>(
+    RESPONSE_SESSION_INDEX_NAMESPACE,
+  );
   const expiresBefore = Date.now() - RESPONSE_SESSION_TTL_MS;
-  const candidates = Object.entries(metadata)
-    .map(([key, value]) => ({ key, ...value }))
+  const candidates = metadataDocuments
+    .map((document) => ({ key: document.key, ...document.value }))
     .sort((left, right) => left.createdAt - right.createdAt);
   const toDelete = candidates.filter(
     (candidate) => candidate.createdAt <= expiresBefore,
@@ -255,15 +227,10 @@ const prunePgResponseSessions = async (): Promise<void> => {
   }
 
   await Promise.all(
-    toDelete.map((candidate) =>
+    toDelete.flatMap((candidate) => [
       deleteStorageJson(RESPONSE_SESSION_NAMESPACE, candidate.key),
-    ),
-  );
-  toDelete.forEach((candidate) => delete metadata[candidate.key]);
-  await writeStorageJson(
-    RESPONSE_SESSION_INDEX_NAMESPACE,
-    RESPONSE_SESSION_INDEX_KEY,
-    metadata,
+      deleteStorageJson(RESPONSE_SESSION_INDEX_NAMESPACE, candidate.key),
+    ]),
   );
 };
 
@@ -282,13 +249,7 @@ const getResponseSession = async (
     if (!session || session.createdAt <= Date.now() - RESPONSE_SESSION_TTL_MS) {
       if (session) {
         await deleteStorageJson(RESPONSE_SESSION_NAMESPACE, id);
-        const metadata = await getPgResponseSessionMetadata();
-        delete metadata[id];
-        await writeStorageJson(
-          RESPONSE_SESSION_INDEX_NAMESPACE,
-          RESPONSE_SESSION_INDEX_KEY,
-          metadata,
-        );
+        await deleteStorageJson(RESPONSE_SESSION_INDEX_NAMESPACE, id);
       }
       return undefined;
     }
@@ -326,17 +287,11 @@ const storeResponseSession = async (
   }
 
   if (isPgResponseSessionStore()) {
-    const metadata = await getPgResponseSessionMetadata();
     await writeStorageJson(RESPONSE_SESSION_NAMESPACE, session.id, session);
-    metadata[session.id] = {
+    await writeStorageJson(RESPONSE_SESSION_INDEX_NAMESPACE, session.id, {
       bytes: Buffer.byteLength(serialized, 'utf8'),
       createdAt: session.createdAt,
-    };
-    await writeStorageJson(
-      RESPONSE_SESSION_INDEX_NAMESPACE,
-      RESPONSE_SESSION_INDEX_KEY,
-      metadata,
-    );
+    });
     try {
       await prunePgResponseSessions();
     } catch (error) {

--- a/lib/server/storage/index.ts
+++ b/lib/server/storage/index.ts
@@ -553,6 +553,7 @@ class DatabaseStorageBackend implements StorageBackend {
   ): Promise<void> {
     const sensitive =
       namespace === 'credentials' ||
+      namespace === 'responses' ||
       (namespace === 'access-keys' && key === 'store');
 
     if (sensitive) {

--- a/tests/server/anthropic.test.ts
+++ b/tests/server/anthropic.test.ts
@@ -566,6 +566,28 @@ describe('anthropic messages api', () => {
     expect(text).toContain('event: message_stop');
   });
 
+  it('terminates streaming when the upstream rejects an oversized SSE frame', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeSseResponse([
+        'data: {"error":{"message":"Upstream SSE frame exceeds the maximum size"}}',
+      ]),
+    );
+
+    const response = await handleMessagesRequest(
+      makeNextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        model: 'claude-sonnet-4.6',
+        max_tokens: 1024,
+        stream: true,
+        messages: [{ role: 'user', content: 'Hi' }],
+      },
+    );
+
+    const text = await response.text();
+    expect(text).toContain('event: error');
+    expect(text).not.toContain('event: message_stop');
+  });
+
   it('cancels the upstream Chat stream when an Anthropic client disconnects', async () => {
     const cancel = vi.fn();
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -41,6 +41,16 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
       encryptionEnabled: true,
       schema: 'codebuddy2api',
     }),
+    listStorageJson: async <T>(namespace: string) => {
+      if (namespace === 'responses') {
+        return [...pgSessions.entries()].map(([key, value]) => ({
+          key,
+          value: value as T,
+        }));
+      }
+
+      return storage.listStorageJson<T>(namespace);
+    },
     readStorageJson: async <T>(namespace: string, key: string) => {
       if (namespace === 'responses') {
         return (await readPgSession(namespace, key)) as T | null;
@@ -93,6 +103,18 @@ const makeChatResponse = (content: string): Response => {
   );
 };
 
+const makeChunkedResponse = (body: string): Response => {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        controller.enqueue(new TextEncoder().encode(body));
+        controller.close();
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  );
+};
+
 describe('Responses memory bounds', () => {
   beforeEach(async () => {
     cleanupTempState();
@@ -117,7 +139,8 @@ describe('Responses memory bounds', () => {
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(makeChatResponse('first response'))
-      .mockResolvedValueOnce(makeChatResponse('follow-up response'));
+      .mockResolvedValueOnce(makeChatResponse('follow-up response'))
+      .mockResolvedValueOnce(makeChatResponse('pruned response'));
 
     const firstResponse = await handleResponsesRequest(makeRequest(), {
       input: 'start',
@@ -151,6 +174,13 @@ describe('Responses memory bounds', () => {
       transcript: [],
     });
 
+    const pruneResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'trigger prune',
+      model: 'gpt-5.5',
+    });
+    expect((await pruneResponse.json()).output_text).toBe('pruned response');
+    expect(deletePgSession).toHaveBeenCalledWith('responses', expiredId);
+
     const expiredResponse = await handleResponsesRequest(makeRequest(), {
       input: 'expired',
       model: 'gpt-5.5',
@@ -158,7 +188,55 @@ describe('Responses memory bounds', () => {
     });
     expect(expiredResponse.status).toBe(400);
     expect(deletePgSession).toHaveBeenCalledWith('responses', expiredId);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('completes the stream when session persistence fails', async () => {
+    writePgSession.mockRejectedValueOnce(new Error('database unavailable'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('data: [DONE]\n\n', {
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'storage failure',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    const text = await response.text();
+
+    expect(text).toContain('response.error');
+    expect(text).toContain('data: [DONE]');
+  });
+
+  it('starts a truncated transcript at a complete tool turn', async () => {
+    const previousId = 'resp_tool_boundary';
+    pgSessions.set(previousId, {
+      accessKeyId: null,
+      createdAt: Date.now(),
+      defaults: { instructions: null, tools: [] },
+      id: previousId,
+      model: 'gpt-5.5',
+      transcript: [
+        { content: '{}', role: 'tool', tool_call_id: 'call-orphan' },
+        { content: 'continue', role: 'user' },
+      ],
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(makeChatResponse('continued'));
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'continue safely',
+      model: 'gpt-5.5',
+      previous_response_id: previousId,
+    });
+    expect(response.status).toBe(200);
+    const requestBody = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    ) as { messages: Array<{ role: string }> };
+    expect(requestBody.messages[0]?.role).toBe('user');
   });
 
   it('does not persist an oversized response session', async () => {
@@ -171,7 +249,7 @@ describe('Responses memory bounds', () => {
       model: 'gpt-5.5',
     });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(413);
     expect(writePgSession).not.toHaveBeenCalled();
   });
 
@@ -201,6 +279,12 @@ describe('Responses memory bounds', () => {
         new Response(
           'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}',
           { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(makeChunkedResponse(oversizedFrame))
+      .mockResolvedValueOnce(
+        makeChunkedResponse(
+          `${oversizedFrame}\n\ndata: {"choices":[{"delta":{"content":"complete"}}]}\n\n`,
         ),
       );
 
@@ -245,7 +329,57 @@ describe('Responses memory bounds', () => {
       stream: true,
     });
     expect(await passthroughStream.text()).toContain('response.completed');
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    const oversizedRemainder = await handleResponsesRequest(makeRequest(), {
+      input: 'oversized remainder',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await oversizedRemainder.text()).toContain('response.completed');
+
+    const oversizedComplete = await handleResponsesRequest(makeRequest(), {
+      input: 'oversized complete frame',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await oversizedComplete.text()).toContain('"complete"');
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it('rejects streamed output and tool arguments above their limits', async () => {
+    const oversizedText = [
+      'x'.repeat(900_000),
+      'x'.repeat(900_000),
+      'x'.repeat(300_001),
+    ];
+    const oversizedArguments = ['x'.repeat(900_000), 'x'.repeat(100_001)];
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          `data: {"choices":[{"delta":{"content":"${oversizedText[0]}"}}]}\n\ndata: {"choices":[{"delta":{"content":"${oversizedText[1]}"}}]}\n\ndata: {"choices":[{"delta":{"content":"${oversizedText[2]}"}}]}\n\n`,
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${oversizedArguments[0]}"}}]}}]}\n\ndata: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${oversizedArguments[1]}"}}]}}]}\n\n`,
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      );
+
+    const textResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'oversized output',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await textResponse.text()).toContain('response.error');
+
+    const argumentResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'oversized arguments',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await argumentResponse.text()).toContain('response.error');
   });
 
   it('retains tool argument deltas until an unnamed streaming tool is finalized', async () => {

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -404,7 +404,7 @@ describe('Responses memory bounds', () => {
       'x'.repeat(300_001),
     ];
     const oversizedArguments = ['x'.repeat(900_000), 'x'.repeat(100_001)];
-    const aggregateToolCalls = Array.from({ length: 73 }, (_, index) => ({
+    const aggregateToolCalls = Array.from({ length: 75 }, (_, index) => ({
       function: { arguments: 'x'.repeat(900_000) },
       index,
     }));
@@ -476,6 +476,27 @@ describe('Responses memory bounds', () => {
     expect(text).toContain('"name":"function"');
     expect(text).toContain('"arguments":"{}"');
     expect(text).toContain('response.function_call_arguments.done');
+  });
+
+  it('rejects unbounded streamed tool names and stops processing the frame batch', async () => {
+    const oversizedName = 'x'.repeat(257);
+    const trailingContent = 'should not be emitted';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, function: { name: oversizedName } }] } }] })}\n\ndata: ${JSON.stringify({ choices: [{ delta: { content: trailingContent } }] })}\n\n`,
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'oversized tool name',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    const text = await response.text();
+
+    expect(text).toContain('response.error');
+    expect(text).not.toContain(trailingContent);
   });
 
   it('emits argument deltas after a streaming tool call is registered', async () => {

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
   return {
     ...storage,
     deleteStorageJson: async (namespace: string, key: string) => {
-      if (namespace === 'responses') {
+      if (namespace === 'responses' || namespace === 'response-session-index') {
         await deletePgSession(namespace, key);
         return;
       }
@@ -42,7 +42,7 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
       schema: 'codebuddy2api',
     }),
     listStorageJson: async <T>(namespace: string) => {
-      if (namespace === 'responses') {
+      if (namespace === 'responses' || namespace === 'response-session-index') {
         return [...pgSessions.entries()].map(([key, value]) => ({
           key,
           value: value as T,
@@ -52,14 +52,14 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
       return storage.listStorageJson<T>(namespace);
     },
     readStorageJson: async <T>(namespace: string, key: string) => {
-      if (namespace === 'responses') {
+      if (namespace === 'responses' || namespace === 'response-session-index') {
         return (await readPgSession(namespace, key)) as T | null;
       }
 
       return storage.readStorageJson<T>(namespace, key);
     },
     writeStorageJson: async <T>(namespace: string, key: string, value: T) => {
-      if (namespace === 'responses') {
+      if (namespace === 'responses' || namespace === 'response-session-index') {
         await writePgSession(namespace, key, value);
         return;
       }
@@ -188,7 +188,9 @@ describe('Responses memory bounds', () => {
     );
 
     const expiredId = 'resp_expired';
-    pgSessions.set(expiredId, {
+    resetResponseSessions();
+    pgSessions.delete('metadata');
+    await writePgSession('responses', expiredId, {
       accessKeyId: null,
       createdAt: Date.now() - 60 * 60 * 1000 - 1,
       defaults: { instructions: null, tools: [] },
@@ -228,6 +230,7 @@ describe('Responses memory bounds', () => {
         transcript: [{ content: expiredContent, role: 'assistant' }],
       });
     });
+    pgSessions.delete('metadata');
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       makeChatResponse('pruned response'),
     );
@@ -239,7 +242,7 @@ describe('Responses memory bounds', () => {
 
     expect(response.status).toBe(200);
     expect(deletePgSession).toHaveBeenCalledTimes(9);
-    expect(pgSessions.size).toBe(1);
+    expect(pgSessions.size).toBe(2);
   });
 
   it('completes the stream when session persistence fails', async () => {
@@ -355,7 +358,7 @@ describe('Responses memory bounds', () => {
         stream: true,
       },
     );
-    expect(await anthropicStream.text()).toContain('"text":"anthropic"');
+    expect(await anthropicStream.text()).toContain('event: error');
 
     const credential = (await listCredentials()).credentials[0];
     const context = await resolveProxyContextByCredentialFilename(

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -164,6 +164,29 @@ describe('Responses memory bounds', () => {
     );
     expect(readPgSession).toHaveBeenCalledWith('responses', firstPayload.id);
 
+    const directlyExpiredId = 'resp_directly_expired';
+    pgSessions.set(directlyExpiredId, {
+      accessKeyId: null,
+      createdAt: Date.now() - 60 * 60 * 1000 - 1,
+      defaults: { instructions: null, tools: [] },
+      id: directlyExpiredId,
+      model: 'gpt-5.5',
+      transcript: [],
+    });
+    const directlyExpiredResponse = await handleResponsesRequest(
+      makeRequest(),
+      {
+        input: 'expired directly',
+        model: 'gpt-5.5',
+        previous_response_id: directlyExpiredId,
+      },
+    );
+    expect(directlyExpiredResponse.status).toBe(400);
+    expect(deletePgSession).toHaveBeenCalledWith(
+      'responses',
+      directlyExpiredId,
+    );
+
     const expiredId = 'resp_expired';
     pgSessions.set(expiredId, {
       accessKeyId: null,
@@ -189,6 +212,34 @@ describe('Responses memory bounds', () => {
     expect(expiredResponse.status).toBe(400);
     expect(deletePgSession).toHaveBeenCalledWith('responses', expiredId);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('prunes expired PostgreSQL sessions before enforcing the byte budget', async () => {
+    const expiredContent = 'x'.repeat(8 * 1024 * 1024);
+    const expiredCreatedAt = Date.now() - 60 * 60 * 1000 - 1;
+    Array.from({ length: 9 }).forEach((_, index) => {
+      const id = `resp_expired_${index}`;
+      pgSessions.set(id, {
+        accessKeyId: null,
+        createdAt: expiredCreatedAt,
+        defaults: { instructions: null, tools: [] },
+        id,
+        model: 'gpt-5.5',
+        transcript: [{ content: expiredContent, role: 'assistant' }],
+      });
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeChatResponse('pruned response'),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'trigger byte-budget prune',
+      model: 'gpt-5.5',
+    });
+
+    expect(response.status).toBe(200);
+    expect(deletePgSession).toHaveBeenCalledTimes(9);
+    expect(pgSessions.size).toBe(1);
   });
 
   it('completes the stream when session persistence fails', async () => {
@@ -353,6 +404,16 @@ describe('Responses memory bounds', () => {
       'x'.repeat(300_001),
     ];
     const oversizedArguments = ['x'.repeat(900_000), 'x'.repeat(100_001)];
+    const aggregateToolCalls = Array.from({ length: 73 }, (_, index) => ({
+      function: { arguments: 'x'.repeat(900_000) },
+      index,
+    }));
+    const aggregateToolPayload = aggregateToolCalls
+      .map(
+        (toolCall) =>
+          `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [toolCall] } }] })}\n\n`,
+      )
+      .join('');
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(
@@ -365,6 +426,11 @@ describe('Responses memory bounds', () => {
           `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${oversizedArguments[0]}"}}]}}]}\n\ndata: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${oversizedArguments[1]}"}}]}}]}\n\n`,
           { headers: { 'Content-Type': 'text/event-stream' } },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(aggregateToolPayload, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
       );
 
     const textResponse = await handleResponsesRequest(makeRequest(), {
@@ -380,6 +446,16 @@ describe('Responses memory bounds', () => {
       stream: true,
     });
     expect(await argumentResponse.text()).toContain('response.error');
+
+    const aggregateArgumentResponse = await handleResponsesRequest(
+      makeRequest(),
+      {
+        input: 'aggregate oversized arguments',
+        model: 'gpt-5.5',
+        stream: true,
+      },
+    );
+    expect(await aggregateArgumentResponse.text()).toContain('response.error');
   });
 
   it('retains tool argument deltas until an unnamed streaming tool is finalized', async () => {
@@ -400,5 +476,24 @@ describe('Responses memory bounds', () => {
     expect(text).toContain('"name":"function"');
     expect(text).toContain('"arguments":"{}"');
     expect(text).toContain('response.function_call_arguments.done');
+  });
+
+  it('emits argument deltas after a streaming tool call is registered', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_registered","function":{"name":"lookup","arguments":"{}"}}]}}]}\n\n',
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'stream registered tool',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+
+    expect(await response.text()).toContain(
+      'response.function_call_arguments.delta',
+    );
   });
 });

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -3,25 +3,32 @@ import path from 'node:path';
 
 import { NextRequest } from 'next/server';
 
-const { deletePgSession, pgSessions, readPgSession, writePgSession } =
-  vi.hoisted(() => {
-    const sessions = new Map<string, unknown>();
+const {
+  deletePgSession,
+  pgIndexSessions,
+  pgSessions,
+  readPgSession,
+  writePgSession,
+} = vi.hoisted(() => {
+  const sessions = new Map<string, unknown>();
+  const indexSessions = new Map<string, unknown>();
 
-    return {
-      deletePgSession: vi.fn(async (_namespace: string, key: string) => {
-        sessions.delete(key);
-      }),
-      pgSessions: sessions,
-      readPgSession: vi.fn(async (_namespace: string, key: string) => {
-        return sessions.get(key) ?? null;
-      }),
-      writePgSession: vi.fn(
-        async (_namespace: string, key: string, value: unknown) => {
-          sessions.set(key, value);
-        },
-      ),
-    };
-  });
+  return {
+    deletePgSession: vi.fn(async (_namespace: string, key: string) => {
+      sessions.delete(key);
+    }),
+    pgSessions: sessions,
+    pgIndexSessions: indexSessions,
+    readPgSession: vi.fn(async (_namespace: string, key: string) => {
+      return sessions.get(key) ?? null;
+    }),
+    writePgSession: vi.fn(
+      async (_namespace: string, key: string, value: unknown) => {
+        sessions.set(key, value);
+      },
+    ),
+  };
+});
 
 vi.mock('@/lib/server/storage', async (importOriginal) => {
   const storage = await importOriginal<typeof import('@/lib/server/storage')>();
@@ -30,7 +37,11 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
     ...storage,
     deleteStorageJson: async (namespace: string, key: string) => {
       if (namespace === 'responses' || namespace === 'response-session-index') {
-        await deletePgSession(namespace, key);
+        if (namespace === 'response-session-index') {
+          pgIndexSessions.delete(key);
+        } else {
+          await deletePgSession(namespace, key);
+        }
         return;
       }
 
@@ -43,7 +54,9 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
     }),
     listStorageJson: async <T>(namespace: string) => {
       if (namespace === 'responses' || namespace === 'response-session-index') {
-        return [...pgSessions.entries()].map(([key, value]) => ({
+        const sessions =
+          namespace === 'response-session-index' ? pgIndexSessions : pgSessions;
+        return [...sessions.entries()].map(([key, value]) => ({
           key,
           value: value as T,
         }));
@@ -53,14 +66,22 @@ vi.mock('@/lib/server/storage', async (importOriginal) => {
     },
     readStorageJson: async <T>(namespace: string, key: string) => {
       if (namespace === 'responses' || namespace === 'response-session-index') {
-        return (await readPgSession(namespace, key)) as T | null;
+        return (
+          namespace === 'response-session-index'
+            ? pgIndexSessions.get(key)
+            : await readPgSession(namespace, key)
+        ) as T | null;
       }
 
       return storage.readStorageJson<T>(namespace, key);
     },
     writeStorageJson: async <T>(namespace: string, key: string, value: T) => {
       if (namespace === 'responses' || namespace === 'response-session-index') {
-        await writePgSession(namespace, key, value);
+        if (namespace === 'response-session-index') {
+          pgIndexSessions.set(key, value);
+        } else {
+          await writePgSession(namespace, key, value);
+        }
         return;
       }
 
@@ -121,6 +142,7 @@ describe('Responses memory bounds', () => {
     resetCredentialRuntimeState();
     resetResponseSessions();
     pgSessions.clear();
+    pgIndexSessions.clear();
     vi.restoreAllMocks();
     vi.clearAllMocks();
     vi.spyOn(process, 'cwd').mockReturnValue(tempRootDir);
@@ -189,7 +211,6 @@ describe('Responses memory bounds', () => {
 
     const expiredId = 'resp_expired';
     resetResponseSessions();
-    pgSessions.delete('metadata');
     await writePgSession('responses', expiredId, {
       accessKeyId: null,
       createdAt: Date.now() - 60 * 60 * 1000 - 1,
@@ -197,6 +218,10 @@ describe('Responses memory bounds', () => {
       id: expiredId,
       model: 'gpt-5.5',
       transcript: [],
+    });
+    pgIndexSessions.set(expiredId, {
+      bytes: 0,
+      createdAt: Date.now() - 60 * 60 * 1000 - 1,
     });
 
     const pruneResponse = await handleResponsesRequest(makeRequest(), {
@@ -230,7 +255,13 @@ describe('Responses memory bounds', () => {
         transcript: [{ content: expiredContent, role: 'assistant' }],
       });
     });
-    pgSessions.delete('metadata');
+    pgIndexSessions.clear();
+    for (const id of Array.from(pgSessions.keys())) {
+      pgIndexSessions.set(id, {
+        bytes: 8 * 1024 * 1024,
+        createdAt: expiredCreatedAt,
+      });
+    }
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       makeChatResponse('pruned response'),
     );
@@ -242,7 +273,8 @@ describe('Responses memory bounds', () => {
 
     expect(response.status).toBe(200);
     expect(deletePgSession).toHaveBeenCalledTimes(9);
-    expect(pgSessions.size).toBe(2);
+    expect(pgSessions.size).toBe(1);
+    expect(pgIndexSessions.size).toBe(1);
   });
 
   it('completes the stream when session persistence fails', async () => {

--- a/tests/server/responses-memory.test.ts
+++ b/tests/server/responses-memory.test.ts
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { NextRequest } from 'next/server';
+
+const { deletePgSession, pgSessions, readPgSession, writePgSession } =
+  vi.hoisted(() => {
+    const sessions = new Map<string, unknown>();
+
+    return {
+      deletePgSession: vi.fn(async (_namespace: string, key: string) => {
+        sessions.delete(key);
+      }),
+      pgSessions: sessions,
+      readPgSession: vi.fn(async (_namespace: string, key: string) => {
+        return sessions.get(key) ?? null;
+      }),
+      writePgSession: vi.fn(
+        async (_namespace: string, key: string, value: unknown) => {
+          sessions.set(key, value);
+        },
+      ),
+    };
+  });
+
+vi.mock('@/lib/server/storage', async (importOriginal) => {
+  const storage = await importOriginal<typeof import('@/lib/server/storage')>();
+
+  return {
+    ...storage,
+    deleteStorageJson: async (namespace: string, key: string) => {
+      if (namespace === 'responses') {
+        await deletePgSession(namespace, key);
+        return;
+      }
+
+      await storage.deleteStorageJson(namespace, key);
+    },
+    getStorageBackendMeta: () => ({
+      backend: 'pg' as const,
+      encryptionEnabled: true,
+      schema: 'codebuddy2api',
+    }),
+    readStorageJson: async <T>(namespace: string, key: string) => {
+      if (namespace === 'responses') {
+        return (await readPgSession(namespace, key)) as T | null;
+      }
+
+      return storage.readStorageJson<T>(namespace, key);
+    },
+    writeStorageJson: async <T>(namespace: string, key: string, value: T) => {
+      if (namespace === 'responses') {
+        await writePgSession(namespace, key, value);
+        return;
+      }
+
+      await storage.writeStorageJson(namespace, key, value);
+    },
+  };
+});
+
+import {
+  addCredential,
+  listCredentials,
+  resetCredentialRuntimeState,
+} from '@/lib/server/domain/credentials';
+import { handleMessagesRequest } from '@/lib/server/proxy/anthropic';
+import {
+  proxyChatCompletions,
+  proxyResponsesUpstream,
+  resolveProxyContextByCredentialFilename,
+} from '@/lib/server/proxy/codebuddy';
+import {
+  handleResponsesRequest,
+  resetResponseSessions,
+} from '@/lib/server/proxy/responses';
+
+const repoRoot = process.cwd();
+const tempRootDir = path.join(repoRoot, '.tmp-test-responses-memory');
+
+const cleanupTempState = (): void => {
+  fs.rmSync(tempRootDir, { force: true, maxRetries: 5, recursive: true });
+};
+
+const makeRequest = (): NextRequest => {
+  return new NextRequest('http://localhost/v1/responses', { method: 'POST' });
+};
+
+const makeChatResponse = (content: string): Response => {
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content } }], model: 'gpt-5.5' }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+};
+
+describe('Responses memory bounds', () => {
+  beforeEach(async () => {
+    cleanupTempState();
+    resetCredentialRuntimeState();
+    resetResponseSessions();
+    pgSessions.clear();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.spyOn(process, 'cwd').mockReturnValue(tempRootDir);
+    await addCredential({
+      bearer_token: 'responses-memory-token',
+      responses_passthrough: false,
+      user_id: 'responses-memory@example.com',
+    });
+  });
+
+  afterEach(() => {
+    cleanupTempState();
+  });
+
+  it('uses PostgreSQL session storage and removes expired sessions', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(makeChatResponse('first response'))
+      .mockResolvedValueOnce(makeChatResponse('follow-up response'));
+
+    const firstResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'start',
+      model: 'gpt-5.5',
+    });
+    const firstPayload = (await firstResponse.json()) as { id: string };
+
+    expect(writePgSession).toHaveBeenCalledWith(
+      'responses',
+      firstPayload.id,
+      expect.objectContaining({ id: firstPayload.id }),
+    );
+
+    const followUpResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'continue',
+      model: 'gpt-5.5',
+      previous_response_id: firstPayload.id,
+    });
+    expect((await followUpResponse.json()).output_text).toBe(
+      'follow-up response',
+    );
+    expect(readPgSession).toHaveBeenCalledWith('responses', firstPayload.id);
+
+    const expiredId = 'resp_expired';
+    pgSessions.set(expiredId, {
+      accessKeyId: null,
+      createdAt: Date.now() - 60 * 60 * 1000 - 1,
+      defaults: { instructions: null, tools: [] },
+      id: expiredId,
+      model: 'gpt-5.5',
+      transcript: [],
+    });
+
+    const expiredResponse = await handleResponsesRequest(makeRequest(), {
+      input: 'expired',
+      model: 'gpt-5.5',
+      previous_response_id: expiredId,
+    });
+    expect(expiredResponse.status).toBe(400);
+    expect(deletePgSession).toHaveBeenCalledWith('responses', expiredId);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not persist an oversized response session', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeChatResponse('x'.repeat(9 * 1024 * 1024)),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'large output',
+      model: 'gpt-5.5',
+    });
+
+    expect(response.status).toBe(200);
+    expect(writePgSession).not.toHaveBeenCalled();
+  });
+
+  it('bounds incomplete SSE frames in every proxy stream', async () => {
+    const oversizedFrame = 'x'.repeat(1_000_001);
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          `${oversizedFrame}\n\ndata: {"choices":[{"delta":{"content":"responses"}}]}`,
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          `${oversizedFrame}\n\ndata: {"id":"chatcmpl_anthropic","model":"gpt-5.5","choices":[{"delta":{"content":"anthropic"}}]}\n\ndata: [DONE]`,
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          `${oversizedFrame}\n\ndata: {"id":"chatcmpl_chat","model":"gpt-5.5","choices":[{"delta":{"content":"chat"}}]}\n\ndata: [DONE]`,
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}',
+          { headers: { 'Content-Type': 'text/event-stream' } },
+        ),
+      );
+
+    const responsesStream = await handleResponsesRequest(makeRequest(), {
+      input: 'stream responses',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await responsesStream.text()).toContain('"output_text":"responses"');
+
+    const anthropicStream = await handleMessagesRequest(
+      new NextRequest('http://localhost/v1/messages', { method: 'POST' }),
+      {
+        max_tokens: 32,
+        messages: [{ content: 'stream anthropic', role: 'user' }],
+        model: 'gpt-5.5',
+        stream: true,
+      },
+    );
+    expect(await anthropicStream.text()).toContain('"text":"anthropic"');
+
+    const credential = (await listCredentials()).credentials[0];
+    const context = await resolveProxyContextByCredentialFilename(
+      String(credential?.filename),
+    );
+    const chatStream = await proxyChatCompletions(
+      new NextRequest('http://localhost/v1/chat/completions', {
+        method: 'POST',
+      }),
+      {
+        messages: [{ content: 'stream chat', role: 'user' }],
+        model: 'gpt-5.5',
+        stream: true,
+      },
+      context,
+    );
+    expect(await chatStream.text()).toContain('"content":"chat"');
+
+    const passthroughStream = await proxyResponsesUpstream(makeRequest(), {
+      input: 'stream passthrough',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    expect(await passthroughStream.text()).toContain('response.completed');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('retains tool argument deltas until an unnamed streaming tool is finalized', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]}}]}\n\n',
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+
+    const response = await handleResponsesRequest(makeRequest(), {
+      input: 'stream anonymous tool',
+      model: 'gpt-5.5',
+      stream: true,
+    });
+    const text = await response.text();
+
+    expect(text).toContain('"name":"function"');
+    expect(text).toContain('"arguments":"{}"');
+    expect(text).toContain('response.function_call_arguments.done');
+  });
+});

--- a/tests/server/storage-backends.test.ts
+++ b/tests/server/storage-backends.test.ts
@@ -322,6 +322,9 @@ describe('storage backends', () => {
     await storage.writeStorageJson('credentials', 'cred-b.json', {
       bearer_token: 'token-b',
     });
+    await storage.writeStorageJson('responses', 'resp-a', {
+      transcript: [{ content: 'sensitive prompt' }],
+    });
     await storage.writeStorageJson('config', 'runtime', {
       CODEBUDDY_AUTH_MODE: 'auto',
     });
@@ -332,6 +335,15 @@ describe('storage backends', () => {
         encryptionMode: 'aes-256-gcm',
         key: 'cred-b.json',
         namespace: 'credentials',
+        payload: null,
+      }),
+    );
+    expect(putDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encryptedPayload: expect.any(String),
+        encryptionMode: 'aes-256-gcm',
+        key: 'resp-a',
+        namespace: 'responses',
         payload: null,
       }),
     );

--- a/tests/server/units.test.ts
+++ b/tests/server/units.test.ts
@@ -2844,6 +2844,66 @@ describe('server units', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps local response byte accounting valid across stale indexes and resets', async () => {
+    const responseState = globalThis as typeof globalThis & {
+      __codebuddy2apiResponseSessionBytes__?: Map<string, number>;
+      __codebuddy2apiResponseSessionTotalBytes__?: number;
+      __codebuddy2apiResponseSessions__?: Map<string, { createdAt: number }>;
+    };
+    delete responseState.__codebuddy2apiResponseSessionTotalBytes__;
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          choices: [{ message: { content: 'first local response' } }],
+          model: 'gpt-5.5',
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          choices: [{ message: { content: 'second local response' } }],
+          model: 'gpt-5.5',
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          choices: [{ message: { content: 'third local response' } }],
+          model: 'gpt-5.5',
+        }),
+      );
+
+    const first = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'first local response', model: 'gpt-5.5' },
+    );
+    const firstId = (await first.json()).id as string;
+    const firstSession =
+      responseState.__codebuddy2apiResponseSessions__!.get(firstId)!;
+    firstSession.createdAt = Date.now() - 60 * 60 * 1000 - 1;
+    await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'prune indexed response', model: 'gpt-5.5' },
+    );
+
+    const second = await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'second local response', model: 'gpt-5.5' },
+    );
+    const secondId = (await second.json()).id as string;
+    const secondSession =
+      responseState.__codebuddy2apiResponseSessions__!.get(secondId)!;
+    secondSession.createdAt = Date.now() - 60 * 60 * 1000 - 1;
+    responseState.__codebuddy2apiResponseSessionBytes__?.delete(secondId);
+    await handleResponsesRequest(
+      makeNextRequest('http://localhost/v1/responses', { method: 'POST' }),
+      { input: 'prune stale index', model: 'gpt-5.5' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    resetResponseSessions();
+    expect(responseState.__codebuddy2apiResponseSessionTotalBytes__).toBe(0);
+  });
+
   it('updates saved credentials by index and normalizes string boolean flags', async () => {
     const createdCredential = await addCredential({
       bearer_token: 'token-original',


### PR DESCRIPTION
## Summary
- store Responses sessions in PostgreSQL storage instead of a process-local cache when PG is configured
- bound file/SQLite session count, transcript size, per-session bytes, and total in-memory bytes
- replace recursive streaming pumps and cap stream buffers, generated text, and tool arguments

## Root cause
Long Responses conversations duplicated full transcripts into a global in-process Map. Long-lived SSE streams also retained recursive async pump closures, while unbounded output and tool argument buffers could grow per request.

## Validation
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test:coverage (188 passed; 93.53% statements)
- bun run build (passed with elevated process permissions)
- git diff --check