### PR TITLE
fix: stabilize GitHub Pages documentation workflow

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install documentation dependencies
         working-directory: docs
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build documentation
         working-directory: docs
@@ -47,6 +47,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/postcss.config.mjs
+++ b/docs/postcss.config.mjs
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
## Summary
- isolate VitePress from the root Tailwind PostCSS configuration
- use frozen docs dependency installation
- build docs on pull requests and deploy only after pushes to main

## Validation
- `bun run docs:build`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:coverage`

The previous Pages failure was caused by the protected github-pages environment rejecting deployments from a feature branch; PR runs now validate the build without attempting deployment.